### PR TITLE
Multi-GPU CLI

### DIFF
--- a/example_train_fx.sh
+++ b/example_train_fx.sh
@@ -5,7 +5,7 @@ python train_fx.py\
   --training config/training/mobilevit.yaml\
   --logging config/logging.yaml\
   --environment config/environment.yaml\
-  --model-checkpoint classification_mobilevit_fx.pt
+  --fx-model-checkpoint classification_mobilevit_fx.pt
 
 
 # python train_fx.py\
@@ -15,7 +15,7 @@ python train_fx.py\
 #   --training config/training/pidnet.yaml\
 #   --logging config/logging.yaml\
 #   --environment config/environment.yaml\
-#   --model-checkpoint segmentation_pidnet_fx.pt
+#   --fx-model-checkpoint segmentation_pidnet_fx.pt
 
 
 #### Multi-GPU training
@@ -31,7 +31,7 @@ python train_fx.py\
 #   --training config/training/vit.yaml\
 #   --logging config/logging.yaml\
 #   --environment config/environment.yaml\
-#   --model-checkpoint classification_vit_fx.pt
+#   --fx-model-checkpoint classification_vit_fx.pt
 
 
 # python -m torch.distributed.launch\

--- a/src/netspresso_trainer/__init__.py
+++ b/src/netspresso_trainer/__init__.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .trainer_common import set_arguments, trainer
+from .trainer_common import parse_args_netspresso, set_arguments, trainer
 
 version = (Path(__file__).parent / "VERSION").read_text().strip()
 

--- a/src/netspresso_trainer/train.py
+++ b/src/netspresso_trainer/train.py
@@ -2,7 +2,9 @@ from netspresso_trainer import trainer
 
 
 def netspresso_train():
-    trainer(is_graphmodule_training=False)
+    is_graphmodule_training = False
+    trainer(is_graphmodule_training=is_graphmodule_training)
     
 def netspresso_train_fx():
-    trainer(is_graphmodule_training=True)
+    is_graphmodule_training = True
+    trainer(is_graphmodule_training=is_graphmodule_training)


### PR DESCRIPTION
nota-github/netspresso-trainer-dev#101

## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #101 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Found some ways for DDP training only with `--num-gpu`, but it makes code messy
  - should import `torch.distributed.run` module
  - Dual arg parser (one for ddp training, the other for our training script)
  - Should run DDP processes as python subprocess
- Other trainer code examples just provide a training script for DDP training without using setuptools' `entry_point`

## Changelog

Please add a brief summary of the change to the Upcoming Release section of the [`CHANGELOG.md`](https://github.com/nota-netspresso/netspresso-trainer/blob/master/CHANGELOG.md) file
and include a link to the PR (formatted in markdown) and a link to your github profile (if you like).

For example:

```
- Added a cool new feature by `@myusername` in `[PR 2023](https://github.com/nota-netspresso/netspresso-trainer/pull/2023)`
```