### PR TITLE
Update segmentation map configuration format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.pt
 *.pth
 *.egg-info
+*.whl
 
 **/*/exp/
 **/*/events*
@@ -17,6 +18,7 @@ data/*
 log/
 pretrained/
 weights/*
+build/
 
 docker-compose.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ No changes to highlight.
 ## Other Changes:
 
 - Add onnx save in best model saving step of graph model training by `@illian01` in [PR 160](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/160).
+- Update to keep community standards by `@illian01` in [PR 162](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/162)
 
 # v0.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features:
 
-No changes to highlight.
+- Support RGB segmentation map and class with label value by `@deepkyu` in [PR 163](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/163)
 
 ## Bug Fixes:
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+netspresso@nota.ai.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Nota Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you found a security vulnerability in NetsPresso Trainer, please report issues at netspresso@nota.ai. We will check you report closely and give our best to fix the problem. When you have a security vulnerability to report, please do not open github issue or pull request so that everyone can notice.
+
+Please include the following information with your report:
+- A detailed description of the vulnerability.
+- A example of the vulnerability.
+
+Please put [netspresso-trainer] tag on your title, so that we can notice your report is related to NetsPresso Trainer.

--- a/config/data/sidewalk-semantic.yaml
+++ b/config/data/sidewalk-semantic.yaml
@@ -9,4 +9,5 @@ data:
     features:
       image: pixel_values
       label: label
+    label_image_format: L
     id_mapping: ['unlabeled', 'flat-road', 'flat-sidewalk', 'flat-crosswalk', 'flat-cyclinglane', 'flat-parkingdriveway', 'flat-railtrack', 'flat-curb', 'human-person', 'human-rider', 'vehicle-car', 'vehicle-truck', 'vehicle-bus', 'vehicle-tramtrain', 'vehicle-motorcycle', 'vehicle-bicycle', 'vehicle-caravan', 'vehicle-cartrailer', 'construction-building', 'construction-door', 'construction-wall', 'construction-fenceguardrail', 'construction-bridge', 'construction-tunnel', 'construction-stairs', 'object-pole', 'object-trafficsign', 'object-trafficlight', 'nature-vegetation', 'nature-terrain', 'sky', 'void-ground', 'void-dynamic', 'void-static', 'void-unclear']

--- a/config/data/voc12.yaml
+++ b/config/data/voc12.yaml
@@ -16,26 +16,27 @@ data:
     pattern:
       image: ~
       label: ~
-  id_mapping: ['background', 'aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor']
-  pallete:
-    - [0, 0, 0]
-    - [128, 0, 0]
-    - [0, 128, 0]
-    - [128, 128, 0]
-    - [0, 0, 128]
-    - [128, 0, 128]
-    - [0, 128, 128]
-    - [128, 128, 128]
-    - [64, 0, 0]
-    - [192, 0, 0]
-    - [64, 128, 0]
-    - [192, 128, 0]
-    - [64, 0, 128]
-    - [192, 0, 128]
-    - [64, 128, 128]
-    - [192, 128, 128]
-    - [0, 64, 0]
-    - [128, 64, 0]
-    - [0, 192, 0]
-    - [128, 192, 0]
-    - [0, 64, 128]
+  id_mapping:
+    (0, 0, 0): background
+    (128, 0, 0): aeroplane
+    (0, 128, 0): bicycle
+    (128, 128, 0): bird
+    (0, 0, 128): boat
+    (128, 0, 128): bottle
+    (0, 128, 128): bus
+    (128, 128, 128): car
+    (64, 0, 0): cat
+    (192, 0, 0): chair
+    (64, 128, 0): cow
+    (192, 128, 0): diningtable
+    (64, 0, 128): dog
+    (192, 0, 128): horse
+    (64, 128, 128): motorbike
+    (192, 128, 128): person
+    (0, 64, 0): pottedplant
+    (128, 64, 0): sheep
+    (0, 192, 0): sofa
+    (128, 192, 0): train
+    (0, 64, 128): tvmonitor
+    (128, 64, 128): void
+  pallete: ~

--- a/config/data/voc12.yaml
+++ b/config/data/voc12.yaml
@@ -16,7 +16,7 @@ data:
     pattern:
       image: ~
       label: ~
-  label_image_format: rgb
+  label_image_mode: rgb
   id_mapping:
     (0, 0, 0): background
     (128, 0, 0): aeroplane

--- a/config/data/voc12.yaml
+++ b/config/data/voc12.yaml
@@ -16,6 +16,7 @@ data:
     pattern:
       image: ~
       label: ~
+  label_image_format: rgb
   id_mapping:
     (0, 0, 0): background
     (128, 0, 0): aeroplane

--- a/config/data/voc12.yaml
+++ b/config/data/voc12.yaml
@@ -16,7 +16,7 @@ data:
     pattern:
       image: ~
       label: ~
-  label_image_mode: rgb
+  label_image_mode: RGB
   id_mapping:
     (0, 0, 0): background
     (128, 0, 0): aeroplane

--- a/config/data/voc12_grayscale_converted.yaml
+++ b/config/data/voc12_grayscale_converted.yaml
@@ -16,7 +16,7 @@ data:
     pattern:
       image: ~
       label: ~
-  label_image_format: L
+  label_image_mode: L
   id_mapping: ['background', 'aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor']
   pallete:
     - [0, 0, 0]

--- a/config/data/voc12_grayscale_converted.yaml
+++ b/config/data/voc12_grayscale_converted.yaml
@@ -1,0 +1,42 @@
+data:
+  name: voc2012
+  task: segmentation
+  format: local
+  path:
+    root: ../../data/VOC12Dataset
+    train:
+      image: image/train
+      label: mask/train
+    valid:
+      image: image/val
+      label: mask/val
+    test:
+      image: ~  # directory for test images
+      label: ~  # directory for test labels
+    pattern:
+      image: ~
+      label: ~
+  label_image_format: L
+  id_mapping: ['background', 'aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor']
+  pallete:
+    - [0, 0, 0]
+    - [128, 0, 0]
+    - [0, 128, 0]
+    - [128, 128, 0]
+    - [0, 0, 128]
+    - [128, 0, 128]
+    - [0, 128, 128]
+    - [128, 128, 128]
+    - [64, 0, 0]
+    - [192, 0, 0]
+    - [64, 128, 0]
+    - [192, 128, 0]
+    - [64, 0, 128]
+    - [192, 0, 128]
+    - [64, 128, 128]
+    - [192, 128, 128]
+    - [0, 64, 0]
+    - [128, 64, 0]
+    - [0, 192, 0]
+    - [128, 192, 0]
+    - [0, 64, 128]

--- a/src/netspresso_trainer/dataloaders/base.py
+++ b/src/netspresso_trainer/dataloaders/base.py
@@ -10,7 +10,7 @@ import torch.utils.data as data
 
 class BaseCustomDataset(data.Dataset):
 
-    def __init__(self, conf_data, conf_augmentation, model_name, idx_to_class, split, samples, transform, with_label):
+    def __init__(self, conf_data, conf_augmentation, model_name, idx_to_class, split, samples, transform, with_label, **kwargs):
         super(BaseCustomDataset, self).__init__()
         self.conf_data = conf_data
         self.conf_augmentation = conf_augmentation

--- a/src/netspresso_trainer/dataloaders/classification/huggingface.py
+++ b/src/netspresso_trainer/dataloaders/classification/huggingface.py
@@ -17,7 +17,8 @@ class ClassificationHFDataset(BaseHFDataset):
             split,
             huggingface_dataset,
             transform=None,
-            with_label=True
+            with_label=True,
+            **kwargs
     ):
         root = conf_data.metadata.repo
         super(ClassificationHFDataset, self).__init__(

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -11,7 +11,7 @@ class ClassificationCustomDataset(BaseCustomDataset):
                  split, samples, transform=None, with_label=True, **kwargs):
         super(ClassificationCustomDataset, self).__init__(
             conf_data, conf_augmentation, model_name, idx_to_class,
-            split, samples, transform, with_label
+            split, samples, transform, with_label, **kwargs
         )
 
     def __getitem__(self, index):

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -8,7 +8,7 @@ from ..base import BaseCustomDataset
 class ClassificationCustomDataset(BaseCustomDataset):
 
     def __init__(self, conf_data, conf_augmentation, model_name, idx_to_class,
-                 split, samples, transform=None, with_label=True):
+                 split, samples, transform=None, with_label=True, **kwargs):
         super(ClassificationCustomDataset, self).__init__(
             conf_data, conf_augmentation, model_name, idx_to_class,
             split, samples, transform, with_label

--- a/src/netspresso_trainer/dataloaders/detection/local.py
+++ b/src/netspresso_trainer/dataloaders/detection/local.py
@@ -38,7 +38,7 @@ def get_label(label_file: Path):
 class DetectionCustomDataset(BaseCustomDataset):
 
     def __init__(self, conf_data, conf_augmentation, model_name, idx_to_class,
-                 split, samples, transform=None, with_label=True):
+                 split, samples, transform=None, with_label=True, **kwargs):
         super(DetectionCustomDataset, self).__init__(
             conf_data, conf_augmentation, model_name, idx_to_class,
             split, samples, transform, with_label

--- a/src/netspresso_trainer/dataloaders/detection/local.py
+++ b/src/netspresso_trainer/dataloaders/detection/local.py
@@ -41,7 +41,7 @@ class DetectionCustomDataset(BaseCustomDataset):
                  split, samples, transform=None, with_label=True, **kwargs):
         super(DetectionCustomDataset, self).__init__(
             conf_data, conf_augmentation, model_name, idx_to_class,
-            split, samples, transform, with_label
+            split, samples, transform, with_label, **kwargs
         )
     
     @staticmethod

--- a/src/netspresso_trainer/dataloaders/segmentation/dataset.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/dataset.py
@@ -114,9 +114,9 @@ class SegmentationDataSampler(BaseDataSampler):
             Path(cache_dir).mkdir(exist_ok=True, parents=True)
         total_dataset = load_dataset(root, name=subset_name, cache_dir=cache_dir)
 
-        assert self.conf_data.metadata.id_mapping is not None
-        id_mapping: Optional[list] = list(self.conf_data.metadata.id_mapping)
-        idx_to_class, label_value_to_idx = load_custom_class_map(id_mapping=id_mapping)
+        assert isinstance(self.conf_data.metadata.id_mapping, (ListConfig, DictConfig))
+
+        idx_to_class, label_value_to_idx = load_custom_class_map(id_mapping=self.conf_data.metadata.id_mapping)
 
         exists_valid = 'validation' in total_dataset
         exists_test = 'test' in total_dataset

--- a/src/netspresso_trainer/dataloaders/segmentation/dataset.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/dataset.py
@@ -4,8 +4,9 @@ from itertools import chain
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
-from omegaconf import DictConfig
+from omegaconf import DictConfig, ListConfig
 from torch.utils.data import random_split
 
 from ..base import BaseDataSampler
@@ -13,14 +14,43 @@ from ..utils.constants import IMG_EXTENSIONS
 from ..utils.misc import natural_key
 
 
-def load_custom_class_map(id_mapping: List[str]):
-    idx_to_class: Dict[int, str] = dict(enumerate(id_mapping))
-    return idx_to_class
+def as_tuple(tuple_string: str) -> Tuple:
+    tuple_string = tuple_string.replace("(", "")
+    tuple_string = tuple_string.replace(")", "")
+    tuple_value = tuple(map(int, tuple_string.split(",")))
+    return tuple_value
+
+
+def load_custom_class_map(id_mapping: Union[ListConfig, DictConfig]) -> Tuple[Dict[int, str], Dict[Union[int, Tuple], int]]:
+    if isinstance(id_mapping, ListConfig):
+        assert isinstance(id_mapping[0], str), f"Unknown type for class name! {type(id_mapping[0])}"
+        idx_to_class: Dict[int, str] = {k: class_name for k, class_name in enumerate(id_mapping)}
+        label_value_to_idx = {k: k for k in enumerate(id_mapping)}
+        return idx_to_class, label_value_to_idx
+
+    idx_to_class: Dict[int, str] = {}
+    label_value_to_idx: Dict[Union[int, Tuple], int] = {}
+    for class_idx, (label_value, class_name) in enumerate(id_mapping.items()):
+        assert isinstance(class_name, str), "You need to format id_mapping with key for class_index, value for class_name."
+        if isinstance(label_value, (int, tuple)):
+            idx_to_class[class_idx] = class_name
+            label_value_to_idx[label_value] = class_idx
+            continue
+
+        # Check tuple string
+        assert isinstance(label_value, str) and label_value.strip().startswith("(") and label_value.strip().endswith(")"), \
+            f"Unknown type for color index! Should be one of (int, tuple-style str, tuple)... but {type(label_value)}"
+        label_value_tuple: Tuple[int, int, int] = as_tuple(label_value)
+        idx_to_class[class_idx] = class_name
+        label_value_to_idx[label_value_tuple] = class_idx
+
+    return idx_to_class, label_value_to_idx
+
 
 class SegmentationDataSampler(BaseDataSampler):
     def __init__(self, conf_data, train_valid_split_ratio):
         super(SegmentationDataSampler, self).__init__(conf_data, train_valid_split_ratio)
-    
+
     def load_data(self, split='train'):
         data_root = Path(self.conf_data.path.root)
         split_dir = self.conf_data.path[split]
@@ -34,33 +64,33 @@ class SegmentationDataSampler(BaseDataSampler):
                 images.extend([str(file) for file in chain(image_dir.glob(f'*{ext}'), image_dir.glob(f'*{ext.upper()}'))])
                 # TODO: get paired data from regex pattern matching (conf_data.path.pattern)
                 labels.extend([str(file) for file in chain(annotation_dir.glob(f'*{ext}'), annotation_dir.glob(f'*{ext.upper()}'))])
-            
+
             images = sorted(images, key=lambda k: natural_key(k))
             labels = sorted(labels, key=lambda k: natural_key(k))
             images_and_targets.extend([{'image': str(image), 'label': str(label)} for image, label in zip(images, labels)])
-            
+
         elif split == 'test':
             for ext in IMG_EXTENSIONS:
                 images_and_targets.extend([{'image': str(file), 'label': None}
-                                        for file in chain(image_dir.glob(f'*{ext}'), image_dir.glob(f'*{ext.upper()}'))])
+                                           for file in chain(image_dir.glob(f'*{ext}'), image_dir.glob(f'*{ext.upper()}'))])
             images_and_targets = sorted(images_and_targets, key=lambda k: natural_key(k['image']))
         else:
             raise AssertionError(f"split should be either {['train', 'valid', 'test']}")
-        
+
         return images_and_targets
-        
+
     def load_samples(self):
         assert self.conf_data.path.train.image is not None
-        assert self.conf_data.id_mapping is not None
-        id_mapping: Optional[list] = list(self.conf_data.id_mapping)
-        idx_to_class = load_custom_class_map(id_mapping=id_mapping)
-        
+        assert isinstance(self.conf_data.id_mapping, (ListConfig, DictConfig))
+
+        idx_to_class, label_value_to_idx = load_custom_class_map(id_mapping=self.conf_data.id_mapping)
+
         exists_valid = self.conf_data.path.valid.image is not None
         exists_test = self.conf_data.path.test.image is not None
-        
+
         valid_samples = None
         test_samples = None
-        
+
         train_samples = self.load_data(split='train')
         if exists_valid:
             valid_samples = self.load_data(split='valid')
@@ -68,30 +98,29 @@ class SegmentationDataSampler(BaseDataSampler):
             test_samples = self.load_data(split='test')
 
         if not exists_valid:
-            num_train_splitted = int(len(train_samples) * self.train_valid_split_ratio) 
-            train_samples, valid_samples = \
-                random_split(train_samples, [num_train_splitted, len(train_samples) - num_train_splitted],
-                                generator=torch.Generator().manual_seed(42))
-        
-        return train_samples, valid_samples, test_samples, {'idx_to_class': idx_to_class}
-    
+            num_train_splitted = int(len(train_samples) * self.train_valid_split_ratio)
+            train_samples, valid_samples = random_split(train_samples, [num_train_splitted, len(train_samples) - num_train_splitted],
+                                                        generator=torch.Generator().manual_seed(42))
+
+        return train_samples, valid_samples, test_samples, {'idx_to_class': idx_to_class, 'label_value_to_idx': label_value_to_idx}
+
     def load_huggingface_samples(self):
         from datasets import load_dataset
-        
+
         cache_dir = Path(self.conf_data.metadata.custom_cache_dir)
         root = self.conf_data.metadata.repo
         subset_name = self.conf_data.metadata.subset
         if cache_dir is not None:
             Path(cache_dir).mkdir(exist_ok=True, parents=True)
         total_dataset = load_dataset(root, name=subset_name, cache_dir=cache_dir)
-        
+
         assert self.conf_data.metadata.id_mapping is not None
         id_mapping: Optional[list] = list(self.conf_data.metadata.id_mapping)
-        idx_to_class = load_custom_class_map(id_mapping=id_mapping)
-        
+        idx_to_class, label_value_to_idx = load_custom_class_map(id_mapping=id_mapping)
+
         exists_valid = 'validation' in total_dataset
         exists_test = 'test' in total_dataset
-        
+
         train_samples = total_dataset['train']
         valid_samples = None
         if exists_valid:
@@ -104,4 +133,4 @@ class SegmentationDataSampler(BaseDataSampler):
             splitted_datasets = train_samples.train_test_split(test_size=(1 - self.train_valid_split_ratio))
             train_samples = splitted_datasets['train']
             valid_samples = splitted_datasets['test']
-        return train_samples, valid_samples, test_samples, {'idx_to_class': idx_to_class}
+        return train_samples, valid_samples, test_samples, {'idx_to_class': idx_to_class, 'label_value_to_idx': label_value_to_idx}

--- a/src/netspresso_trainer/dataloaders/segmentation/dataset.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/dataset.py
@@ -24,7 +24,7 @@ def as_tuple(tuple_string: str) -> Tuple:
 def load_custom_class_map(id_mapping: Union[ListConfig, DictConfig]) -> Tuple[Dict[int, str], Dict[Union[int, Tuple], int]]:
     if isinstance(id_mapping, ListConfig):
         assert isinstance(id_mapping[0], str), f"Unknown type for class name! {type(id_mapping[0])}"
-        idx_to_class: Dict[int, str] = {k: class_name for k, class_name in enumerate(id_mapping)}
+        idx_to_class: Dict[int, str] = dict(enumerate(id_mapping))
         label_value_to_idx = {k: k for k in idx_to_class}
         return idx_to_class, label_value_to_idx
 

--- a/src/netspresso_trainer/dataloaders/segmentation/dataset.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/dataset.py
@@ -25,7 +25,7 @@ def load_custom_class_map(id_mapping: Union[ListConfig, DictConfig]) -> Tuple[Di
     if isinstance(id_mapping, ListConfig):
         assert isinstance(id_mapping[0], str), f"Unknown type for class name! {type(id_mapping[0])}"
         idx_to_class: Dict[int, str] = {k: class_name for k, class_name in enumerate(id_mapping)}
-        label_value_to_idx = {k: k for k in enumerate(id_mapping)}
+        label_value_to_idx = {k: k for k in idx_to_class}
         return idx_to_class, label_value_to_idx
 
     idx_to_class: Dict[int, str] = {}

--- a/src/netspresso_trainer/dataloaders/segmentation/huggingface.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/huggingface.py
@@ -1,6 +1,7 @@
-import os
+from typing import Literal
 
 import numpy as np
+import PIL.Image as Image
 
 from ..base import BaseHFDataset
 from ..segmentation.transforms import generate_edge, reduce_label
@@ -17,7 +18,8 @@ class SegmentationHFDataset(BaseHFDataset):
             split,
             huggingface_dataset,
             transform=None,
-            with_label=True
+            with_label=True,
+            **kwargs
     ):
         root = conf_data.metadata.repo
         super(SegmentationHFDataset, self).__init__(
@@ -28,11 +30,17 @@ class SegmentationHFDataset(BaseHFDataset):
             split,
             with_label
         )
-        
+
         self.transform = transform
         self.idx_to_class = idx_to_class
         self.samples = huggingface_dataset
-        
+
+        assert "label_value_to_idx" in kwargs
+        self.label_value_to_idx = kwargs["label_value_to_idx"]
+
+        self.label_image_format: Literal['RGB', 'L', 'P'] = str(conf_data.metadata.label_image_format).upper() \
+            if conf_data.metadata.label_image_format is not None else 'RGB'
+
         self.image_feature_name = conf_data.metadata.features.image
         self.label_feature_name = conf_data.metadata.features.label
 
@@ -48,13 +56,23 @@ class SegmentationHFDataset(BaseHFDataset):
         return self.samples.num_rows
 
     def __getitem__(self, index):
-        
-        img_name =  f"{index:06d}"
+
+        img_name = f"{index:06d}"
         img = self.samples[index][self.image_feature_name]
         label = self.samples[index][self.label_feature_name] if self.label_feature_name in self.samples[index] else None
 
-        org_img = img.copy()
+        label_array = np.array(label)
+        label_array = label_array[..., np.newaxis] if label_array.ndim == 2 else label_array
+        # if self.conf_augmentation.reduce_zero_label:
+        #     label = reduce_label(np.array(label))
 
+        mask = np.zeros((label.size[1], label.size[0]), dtype=np.uint8)
+        for label_value in self.label_value_to_idx:
+            class_mask = (label_array == np.array(label_value)).all(axis=-1)
+            mask[class_mask] = self.label_value_to_idx[label_value]
+        mask = Image.fromarray(mask, mode='L')  # single mode array (PIL.Image) compatbile with torchvision transform API
+
+        org_img = img.copy()
         w, h = img.size
 
         if label is None:
@@ -65,10 +83,10 @@ class SegmentationHFDataset(BaseHFDataset):
 
         if self.model_name == 'pidnet':
             edge = generate_edge(np.array(label))
-            out = self.transform(self.conf_augmentation)(image=img, mask=label, edge=edge)
+            out = self.transform(self.conf_augmentation)(image=img, mask=mask, edge=edge)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'edges': out['edge'].float(), 'name': img_name})
         else:
-            out = self.transform(self.conf_augmentation)(image=img, mask=label)
+            out = self.transform(self.conf_augmentation)(image=img, mask=mask)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'name': img_name})
 
         if self._split in ['train', 'training']:

--- a/src/netspresso_trainer/dataloaders/segmentation/huggingface.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/huggingface.py
@@ -38,8 +38,8 @@ class SegmentationHFDataset(BaseHFDataset):
         assert "label_value_to_idx" in kwargs
         self.label_value_to_idx = kwargs["label_value_to_idx"]
 
-        self.label_image_format: Literal['RGB', 'L', 'P'] = str(conf_data.metadata.label_image_format).upper() \
-            if conf_data.metadata.label_image_format is not None else 'RGB'
+        self.label_image_mode: Literal['RGB', 'L', 'P'] = str(conf_data.metadata.label_image_mode).upper() \
+            if conf_data.metadata.label_image_mode is not None else 'L'
 
         self.image_feature_name = conf_data.metadata.features.image
         self.label_feature_name = conf_data.metadata.features.label
@@ -58,10 +58,10 @@ class SegmentationHFDataset(BaseHFDataset):
     def __getitem__(self, index):
 
         img_name = f"{index:06d}"
-        img = self.samples[index][self.image_feature_name]
-        label = self.samples[index][self.label_feature_name] if self.label_feature_name in self.samples[index] else None
+        img: Image.Image = self.samples[index][self.image_feature_name]
+        label: Image.Image = self.samples[index][self.label_feature_name] if self.label_feature_name in self.samples[index] else None
 
-        label_array = np.array(label)
+        label_array = np.array(label.convert(self.label_image_mode))
         label_array = label_array[..., np.newaxis] if label_array.ndim == 2 else label_array
         # if self.conf_augmentation.reduce_zero_label:
         #     label = reduce_label(np.array(label))

--- a/src/netspresso_trainer/dataloaders/segmentation/local.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/local.py
@@ -46,8 +46,7 @@ class SegmentationCustomDataset(BaseCustomDataset):
 
         mask = np.zeros((label.size[1], label.size[0]), dtype=np.uint8)
         for label_value in self.label_value_to_idx:
-            bool_mask = (label_array == np.array(label_value))
-            class_mask = (bool_mask.sum(-1) == label_array.shape[-1])  # match all channel values
+            class_mask = (label_array == np.array(label_value)).all(axis=-1)
             mask[class_mask] = self.label_value_to_idx[label_value]
 
         mask = Image.fromarray(mask, mode='L')  # single mode array (PIL.Image) compatbile with torchvision transform API

--- a/src/netspresso_trainer/dataloaders/segmentation/local.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/local.py
@@ -15,7 +15,7 @@ class SegmentationCustomDataset(BaseCustomDataset):
                  split, samples, transform=None, with_label=True, **kwargs):
         super(SegmentationCustomDataset, self).__init__(
             conf_data, conf_augmentation, model_name, idx_to_class,
-            split, samples, transform, with_label
+            split, samples, transform, with_label, **kwargs
         )
         assert "label_value_to_idx" in kwargs
         self.label_value_to_idx = kwargs["label_value_to_idx"]

--- a/src/netspresso_trainer/dataloaders/segmentation/local.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/local.py
@@ -20,8 +20,8 @@ class SegmentationCustomDataset(BaseCustomDataset):
         assert "label_value_to_idx" in kwargs
         self.label_value_to_idx = kwargs["label_value_to_idx"]
 
-        self.label_image_format: Literal['RGB', 'L', 'P'] = str(conf_data.label_image_format).upper() \
-            if conf_data.label_image_format is not None else 'RGB'
+        self.label_image_mode: Literal['RGB', 'L', 'P'] = str(conf_data.label_image_mode).upper() \
+            if conf_data.label_image_mode is not None else 'L'
 
     def __getitem__(self, index):
         img_path = Path(self.samples[index]['image'])
@@ -38,7 +38,7 @@ class SegmentationCustomDataset(BaseCustomDataset):
 
         outputs = {}
 
-        label = Image.open(ann_path).convert(self.label_image_format)
+        label = Image.open(ann_path).convert(self.label_image_mode)
         label_array = np.array(label)
         label_array = label_array[..., np.newaxis] if label_array.ndim == 2 else label_array
         # if self.conf_augmentation.reduce_zero_label:


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #150

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Update segmentation dataset configuraiton
  - User can select label image mode when loading image with pillow (field: `label_image_mode`)
    - Supporting image modes: `RGB`, `L`, `P` (default: `L`)
  - User can input the class name with RGB or L label value
    - Support both `list` and `dict` for `id_mapping`
- Those changes are applied to both local dataset and huggingface dataset

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 