### PR TITLE
#161 update macs calibration library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@
 
 ## Breaking Changes:
 
-No changes to highlight.
+- Release NetsPresso Trainer colab tutorial `@illian01` in [PR 191](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/191)
 
 ## Other Changes:
 
 - Fix Faster R-CNN detection head by `@illian01` in [PR 184](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/184), [PR 194](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/194)
 - Refactoring models/op module by `@illian01` in [PR 189](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/189), [PR 190](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/190)
-- Release NetsPresso Trainer colab tutorial `@illian01` in [PR 191](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/191)
 - Parameterize activation function of BasicBlock and Bottleneck by `@illian01` in [PR193](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/193)
 - Modify MobileNetV3 to stage format and remove forward hook by `@illian01` in [PR 199](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/199)
+- Substitute MACs counter with `fvcore` library to sync with NetsPresso by `@deepkyu` and `@Only-bottle` in [PR 202](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/202)
 
 # v0.0.8
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 omegaconf
 opencv-python
 tensorboard
+fvcore

--- a/src/netspresso_trainer/utils/stats.py
+++ b/src/netspresso_trainer/utils/stats.py
@@ -3,12 +3,26 @@ from typing import TypedDict
 import thop
 import torch
 import torch.nn as nn
+from fvcore.nn import FlopCountAnalysis
 
 from .environment import get_device
 
 
 def get_params_and_macs(model: nn.Module, sample_input: torch.Tensor):
     sample_input = sample_input.to(get_device(model))
-    macs, params = thop.profile(model, inputs=(sample_input,), verbose=False)
+    # From v0.0.9
+    macs, params = _params_and_macs_fvcore(model, sample_input)
+    
+    # # Before v0.0.9
+    # macs, params = _params_and_macs_thop(model, sample_input)
 
+    return macs, params
+
+def _params_and_macs_fvcore(model: nn.Module, sample_input: torch.Tensor):
+    macs = FlopCountAnalysis(model, sample_input).total()
+    params = sum(p.numel() for p in model.parameters())
+    return macs, params
+
+def _params_and_macs_thop(model: nn.Module, sample_input: torch.Tensor):
+    macs, params = thop.profile(model, inputs=(sample_input,), verbose=False)
     return macs, params


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #161

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Synchronize MACs calibration library with PyNetsPresso and NetsPresso platform
  - https://docs.netspresso.ai/docs/release-notes

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 