### PR TITLE
Apply `get_metric_with_all_outputs` on train step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Parameterize activation function of BasicBlock and Bottleneck by `@illian01` in [PR193](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/193)
 - Modify MobileNetV3 to stage format and remove forward hook by `@illian01` in [PR 199](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/199)
 - Substitute MACs counter with `fvcore` library to sync with NetsPresso by `@deepkyu` and `@Only-bottle` in [PR 202](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/202)
+- Enable to compute metric with all training samples by `@illian01` in [PR 210](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/210)
 
 # v0.0.8
 

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -130,7 +130,7 @@ class BasePipeline(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_metric_with_all_outputs(self, outputs, phase):
+    def get_metric_with_all_outputs(self, outputs, phase: Literal['train', 'valid']):
         raise NotImplementedError
 
     @property

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -130,7 +130,7 @@ class BasePipeline(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_metric_with_all_outputs(self, outputs):
+    def get_metric_with_all_outputs(self, outputs, phase):
         raise NotImplementedError
 
     @property
@@ -205,8 +205,11 @@ class BasePipeline(ABC):
             raise e
 
     def train_one_epoch(self):
+        outputs = []
         for _idx, batch in enumerate(tqdm(self.train_dataloader, leave=False)):
-            self.train_step(batch)
+            out = self.train_step(batch)
+            outputs.append(out)
+        self.get_metric_with_all_outputs(outputs, phase='train')
 
     @torch.no_grad()
     def validate(self, num_samples=NUM_SAMPLES):
@@ -220,7 +223,7 @@ class BasePipeline(ABC):
                 if num_returning_samples < num_samples:
                     returning_samples.append(out)
                     num_returning_samples += len(out['pred'])
-        self.get_metric_with_all_outputs(outputs)
+        self.get_metric_with_all_outputs(outputs, phase='valid')
         return returning_samples
 
     @torch.no_grad()

--- a/src/netspresso_trainer/pipelines/classification.py
+++ b/src/netspresso_trainer/pipelines/classification.py
@@ -61,5 +61,5 @@ class ClassificationPipeline(BasePipeline):
 
         return pred
 
-    def get_metric_with_all_outputs(self, outputs):
+    def get_metric_with_all_outputs(self, outputs, phase):
         pass

--- a/src/netspresso_trainer/pipelines/classification.py
+++ b/src/netspresso_trainer/pipelines/classification.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Literal
 
 import torch
 from omegaconf import OmegaConf
@@ -61,5 +62,5 @@ class ClassificationPipeline(BasePipeline):
 
         return pred
 
-    def get_metric_with_all_outputs(self, outputs, phase):
+    def get_metric_with_all_outputs(self, outputs, phase: Literal['train', 'valid']):
         pass

--- a/src/netspresso_trainer/pipelines/detection.py
+++ b/src/netspresso_trainer/pipelines/detection.py
@@ -120,23 +120,23 @@ class TwoStageDetectionPipeline(BasePipeline):
         # TODO: Compute metrics for train phase
         if phase == 'train':
             return
+        else:
+            pred = []
+            targets = []
+            for output_batch in outputs:
+                for detection, class_idx in output_batch['target']:
+                    target_on_image = {}
+                    target_on_image['boxes'] = detection
+                    target_on_image['labels'] = class_idx
+                    targets.append(target_on_image)
 
-        pred = []
-        targets = []
-        for output_batch in outputs:
-            for detection, class_idx in output_batch['target']:
-                target_on_image = {}
-                target_on_image['boxes'] = detection
-                target_on_image['labels'] = class_idx
-                targets.append(target_on_image)
-
-            for detection, class_idx in output_batch['pred']:
-                pred_on_image = {}
-                pred_on_image['post_boxes'] = detection[..., :4]
-                pred_on_image['post_scores'] = detection[..., -1]
-                pred_on_image['post_labels'] = class_idx
-                pred.append(pred_on_image)
-        self.metric_factory.calc(pred, target=targets, phase=phase)
+                for detection, class_idx in output_batch['pred']:
+                    pred_on_image = {}
+                    pred_on_image['post_boxes'] = detection[..., :4]
+                    pred_on_image['post_scores'] = detection[..., -1]
+                    pred_on_image['post_labels'] = class_idx
+                    pred.append(pred_on_image)
+            self.metric_factory.calc(pred, target=targets, phase=phase)
         
     def save_checkpoint(self, epoch: int):
 

--- a/src/netspresso_trainer/pipelines/detection.py
+++ b/src/netspresso_trainer/pipelines/detection.py
@@ -120,23 +120,23 @@ class TwoStageDetectionPipeline(BasePipeline):
         # TODO: Compute metrics for train phase
         if phase == 'train':
             return
-        else:
-            pred = []
-            targets = []
-            for output_batch in outputs:
-                for detection, class_idx in output_batch['target']:
-                    target_on_image = {}
-                    target_on_image['boxes'] = detection
-                    target_on_image['labels'] = class_idx
-                    targets.append(target_on_image)
+        
+        pred = []
+        targets = []
+        for output_batch in outputs:
+            for detection, class_idx in output_batch['target']:
+                target_on_image = {}
+                target_on_image['boxes'] = detection
+                target_on_image['labels'] = class_idx
+                targets.append(target_on_image)
 
-                for detection, class_idx in output_batch['pred']:
-                    pred_on_image = {}
-                    pred_on_image['post_boxes'] = detection[..., :4]
-                    pred_on_image['post_scores'] = detection[..., -1]
-                    pred_on_image['post_labels'] = class_idx
-                    pred.append(pred_on_image)
-            self.metric_factory.calc(pred, target=targets, phase=phase)
+            for detection, class_idx in output_batch['pred']:
+                pred_on_image = {}
+                pred_on_image['post_boxes'] = detection[..., :4]
+                pred_on_image['post_scores'] = detection[..., -1]
+                pred_on_image['post_labels'] = class_idx
+                pred.append(pred_on_image)
+        self.metric_factory.calc(pred, target=targets, phase=phase)
         
     def save_checkpoint(self, epoch: int):
 

--- a/src/netspresso_trainer/pipelines/detection.py
+++ b/src/netspresso_trainer/pipelines/detection.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 import torch
@@ -116,11 +117,11 @@ class TwoStageDetectionPipeline(BasePipeline):
 
         return results
 
-    def get_metric_with_all_outputs(self, outputs, phase):
+    def get_metric_with_all_outputs(self, outputs, phase: Literal['train', 'valid']):
         # TODO: Compute metrics for train phase
         if phase == 'train':
             return
-        
+
         pred = []
         targets = []
         for output_batch in outputs:

--- a/src/netspresso_trainer/pipelines/detection.py
+++ b/src/netspresso_trainer/pipelines/detection.py
@@ -116,7 +116,11 @@ class TwoStageDetectionPipeline(BasePipeline):
 
         return results
 
-    def get_metric_with_all_outputs(self, outputs):
+    def get_metric_with_all_outputs(self, outputs, phase):
+        # TODO: Compute metrics for train phase
+        if phase == 'train':
+            return
+
         pred = []
         targets = []
         for output_batch in outputs:
@@ -132,7 +136,7 @@ class TwoStageDetectionPipeline(BasePipeline):
                 pred_on_image['post_scores'] = detection[..., -1]
                 pred_on_image['post_labels'] = class_idx
                 pred.append(pred_on_image)
-        self.metric_factory.calc(pred, target=targets, phase='valid')
+        self.metric_factory.calc(pred, target=targets, phase=phase)
         
     def save_checkpoint(self, epoch: int):
 

--- a/src/netspresso_trainer/pipelines/segmentation.py
+++ b/src/netspresso_trainer/pipelines/segmentation.py
@@ -90,5 +90,5 @@ class SegmentationPipeline(BasePipeline):
 
         return output_seg
 
-    def get_metric_with_all_outputs(self, outputs):
+    def get_metric_with_all_outputs(self, outputs, phase):
         pass

--- a/src/netspresso_trainer/pipelines/segmentation.py
+++ b/src/netspresso_trainer/pipelines/segmentation.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Literal
 
 import numpy as np
 import torch
@@ -90,5 +91,5 @@ class SegmentationPipeline(BasePipeline):
 
         return output_seg
 
-    def get_metric_with_all_outputs(self, outputs, phase):
+    def get_metric_with_all_outputs(self, outputs, phase: Literal['train', 'valid']):
         pass


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #209 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Modify `get_metric_with_all_outputs` method of base pipeline and all tasks.
- Collect samples and call `get_metric_with_all_outputs` in train phase.

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 