### PR TITLE
Fix bounding box coordinates computing error on random flip augmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Bug Fixes:
 
 - Remove fx training flag in entry point by `@illian01` in [PR 188](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/188)
+- Fix bounding box coordinates computing error on random flip augmentation by `@illian01` in [PR 211](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/211)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -122,7 +122,7 @@ class RandomHorizontalFlip:
             if mask is not None:
                 mask = F.hflip(mask)
             if bbox is not None:
-                bbox[..., 0:4:2] = w - bbox[..., 0:4:2]
+                bbox[..., 2::-2] = w - bbox[..., 0:4:2]
         return image, mask, bbox
 
     def __repr__(self):
@@ -142,7 +142,7 @@ class RandomVerticalFlip:
             if mask is not None:
                 mask = F.vflip(mask)
             if bbox is not None:
-                bbox[..., 1:4:2] = h - bbox[..., 1:4:2]
+                bbox[..., 3::-2] = h - bbox[..., 1:4:2]
         return image, mask, bbox
 
     def __repr__(self):


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #196 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Horizontal flip example
```
sample1 = bbox.copy()
sample1[..., 0:4:2] = w - sample1[..., 0:4:2]
sample2 = bbox.copy()
sample2[..., 2::-2] = w - sample2[..., 0:4:2]

bbox
>> array([[308.70588235, 214.4       , 327.15294118, 247.04      , 0.      ],
          [306.44705882, 170.24      , 332.04705882, 214.4       , 3.      ]])
sample1
>> array([[203.29411765, 214.4       , 184.84705882, 247.04      , 0.      ],
          [205.55294118, 170.24      , 179.95294118, 214.4       , 3.      ]])
sample2
>> array([[184.84705882, 214.4       , 203.29411765, 247.04      , 0.      ],
          [179.95294118, 170.24      , 205.55294118, 214.4       , 3.      ]])
```

- Vertical flip example
```
sample1 = bbox.copy()
sample1[..., 1:4:2] = h - sample1[..., 1:4:2]
sample2 = bbox.copy()
sample2[..., 3::-2] = h - sample2[..., 1:4:2]

bbox
>> array([[256.        , 275.2       , 267.29411765, 293.12      , 1.      ],
          [293.27058824, 268.8       , 301.55294118, 283.52      , 0.      ]])
sample1
>> array([[256.        , 236.8       , 267.29411765, 218.88      , 1.      ],
          [293.27058824, 243.2       , 301.55294118, 228.48      , 0.      ]])
sample2
>> array([[256.        , 218.88      , 267.29411765, 236.8       ,1.      ],
          [293.27058824, 228.48      , 301.55294118, 243.2       , 0.      ]])
```

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 