### PR TITLE
Support augmentation for classification task: cutmix, mixup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features:
 
 - Add a gpu option in `train_with_config` (only single-GPU supported) by `@deepkyu` in [PR 219](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/219)
+- Support augmentation for classification task: cutmix, mixup by `@illian01` in [PR 221](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/221)
 
 ## Bug Fixes:
 

--- a/config/augmentation/classification.yaml
+++ b/config/augmentation/classification.yaml
@@ -8,3 +8,7 @@ augmentation:
     - 
       name: randomhorizontalflip
       p: 0.5
+  mix_transforms:
+    -
+      name: cutmix
+      alpha: 1.0

--- a/config/augmentation/classification.yaml
+++ b/config/augmentation/classification.yaml
@@ -1,6 +1,6 @@
 augmentation:
   img_size: &img_size 256
-  recipe:
+  transforms:
     - 
       name: randomresizedcrop
       size: *img_size

--- a/config/augmentation/detection.yaml
+++ b/config/augmentation/detection.yaml
@@ -1,6 +1,6 @@
 augmentation:
   img_size: &img_size 512
-  recipe:
+  transforms:
     - 
       name: resize
       size: *img_size

--- a/config/augmentation/segmentation.yaml
+++ b/config/augmentation/segmentation.yaml
@@ -1,6 +1,6 @@
 augmentation:
   img_size: &img_size 512
-  recipe:
+  transforms:
     - 
       name: randomresizedcrop
       size: *img_size

--- a/config/augmentation/template/common.yaml
+++ b/config/augmentation/template/common.yaml
@@ -24,3 +24,4 @@ augmentation:
     -
       name: pad
       padding: ~
+  mix_transforms: ~

--- a/config/augmentation/template/common.yaml
+++ b/config/augmentation/template/common.yaml
@@ -1,6 +1,6 @@
 augmentation:
   img_size: &img_size ~
-  recipe:
+  transforms:
     - 
       name: randomresizedcrop
       size: ~

--- a/src/netspresso_trainer/cfg/augmentation.py
+++ b/src/netspresso_trainer/cfg/augmentation.py
@@ -18,6 +18,7 @@ class AugmentationConfig:
     transforms: List[Transform] = field(default_factory=lambda: [
         Transform()
     ])
+    mix_transforms: Optional[List[Transform]] = None
 
 
 @dataclass
@@ -70,11 +71,28 @@ class Resize(Transform):
 
 
 @dataclass
+class RandomMixup(Transform):
+    name: str = 'mixup'
+    alpha: float = 0.2
+    p: float = 1.0
+
+
+@dataclass
+class RandomCutmix(Transform):
+    name: str = 'cutmix'
+    alpha: float = 1.0
+    p: float = 1.0
+
+
+@dataclass
 class ClassificationAugmentationConfig(AugmentationConfig):
     img_size: int = 256
     transforms: List[Transform] = field(default_factory=lambda: [
         RandomResizedCrop(size=256),
         RandomHorizontalFlip()
+    ])
+    mix_transforms: List[Transform] = field(default_factory=lambda: [
+        RandomCutmix(),
     ])
 
 

--- a/src/netspresso_trainer/cfg/augmentation.py
+++ b/src/netspresso_trainer/cfg/augmentation.py
@@ -15,7 +15,7 @@ class Transform:
 @dataclass
 class AugmentationConfig:
     img_size: int = DEFAULT_IMG_SIZE
-    recipe: List[Transform] = field(default_factory=lambda: [
+    transforms: List[Transform] = field(default_factory=lambda: [
         Transform()
     ])
 
@@ -72,7 +72,7 @@ class Resize(Transform):
 @dataclass
 class ClassificationAugmentationConfig(AugmentationConfig):
     img_size: int = 256
-    recipe: List[Transform] = field(default_factory=lambda: [
+    transforms: List[Transform] = field(default_factory=lambda: [
         RandomResizedCrop(size=256),
         RandomHorizontalFlip()
     ])
@@ -81,7 +81,7 @@ class ClassificationAugmentationConfig(AugmentationConfig):
 @dataclass
 class SegmentationAugmentationConfig(AugmentationConfig):
     img_size: int = 512
-    recipe: List[Transform] = field(default_factory=lambda: [
+    transforms: List[Transform] = field(default_factory=lambda: [
         RandomResizedCrop(size=512),
         RandomHorizontalFlip(),
         ColorJitter()
@@ -91,6 +91,6 @@ class SegmentationAugmentationConfig(AugmentationConfig):
 @dataclass
 class DetectionAugmentationConfig(AugmentationConfig):
     img_size: int = 512
-    recipe: List[Transform] = field(default_factory=lambda: [
+    transforms: List[Transform] = field(default_factory=lambda: [
         Resize(size=512)
     ])

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -376,13 +376,13 @@ class RandomMixup:
 
     def _apply_mixup_transform(self, image_tensor, target_tensor):
         if image_tensor.ndim != 4:
-            print(f"Batch ndim should be 4. Got {image_tensor.ndim}")
+            raise ValueError(f"Batch ndim should be 4. Got {image_tensor.ndim}")
         if target_tensor.ndim != 1:
-            print(f"Target ndim should be 1. Got {target_tensor.ndim}")
+            raise ValueError(f"Target ndim should be 1. Got {target_tensor.ndim}")
         if not image_tensor.is_floating_point():
-            print(f"Batch datatype should be a float tensor. Got {image_tensor.dtype}.")
+            raise ValueError(f"Batch datatype should be a float tensor. Got {image_tensor.dtype}.")
         if target_tensor.dtype != torch.int64:
-            print(f"Target datatype should be torch.int64. Got {target_tensor.dtype}")
+            raise ValueError(f"Target datatype should be torch.int64. Got {target_tensor.dtype}")
 
         if not self.inplace:
             image_tensor = image_tensor.clone()
@@ -449,13 +449,13 @@ class RandomCutmix:
 
     def _apply_cutmix_transform(self, image_tensor, target_tensor):
         if image_tensor.ndim != 4:
-            print(f"Batch ndim should be 4. Got {image_tensor.ndim}")
+            raise ValueError(f"Batch ndim should be 4. Got {image_tensor.ndim}")
         if target_tensor.ndim != 1:
-            print(f"Target ndim should be 1. Got {target_tensor.ndim}")
+            raise ValueError(f"Target ndim should be 1. Got {target_tensor.ndim}")
         if not image_tensor.is_floating_point():
-            print(f"Batch dtype should be a float tensor. Got {image_tensor.dtype}.")
+            raise ValueError(f"Batch dtype should be a float tensor. Got {image_tensor.dtype}.")
         if target_tensor.dtype != torch.int64:
-            print(f"Target dtype should be torch.int64. Got {target_tensor.dtype}")
+            raise ValueError(f"Target dtype should be torch.int64. Got {target_tensor.dtype}")
 
         if not self.inplace:
             image_tensor = image_tensor.clone()

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -353,6 +353,9 @@ class RandomResizedCrop(T.RandomResizedCrop):
 
 class RandomMixup:
     """
+    Based on the RandomCutmix implementation of ml_cvnets.
+    https://github.com/apple/ml-cvnets/blob/77717569ab4a852614dae01f010b32b820cb33bb/data/transforms/image_torch.py
+
     Given a batch of input images and labels, this class randomly applies the
     `MixUp transformation <https://arxiv.org/abs/1710.09412>`_
 
@@ -426,6 +429,9 @@ class RandomMixup:
 
 class RandomCutmix:
     """
+    Based on the RandomCutmix implementation of ml_cvnets.
+    https://github.com/apple/ml-cvnets/blob/77717569ab4a852614dae01f010b32b820cb33bb/data/transforms/image_torch.py
+
     Given a batch of input images and labels, this class randomly applies the
     `CutMix transformation <https://arxiv.org/abs/1905.04899>`_
 

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -353,7 +353,7 @@ class RandomResizedCrop(T.RandomResizedCrop):
 
 class RandomMixup:
     """
-    Based on the RandomCutmix implementation of ml_cvnets.
+    Based on the RandomMixup implementation of ml_cvnets.
     https://github.com/apple/ml-cvnets/blob/77717569ab4a852614dae01f010b32b820cb33bb/data/transforms/image_torch.py
 
     Given a batch of input images and labels, this class randomly applies the

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -363,6 +363,7 @@ class RandomMixup:
         opts (argparse.Namespace): Arguments
         num_classes (int): Number of classes in the dataset
     """
+    visualize = False
 
     def __init__(self, num_classes: int, alpha, p=1.0, inplace=False):
         if not (num_classes > 0):
@@ -439,6 +440,7 @@ class RandomCutmix:
         opts (argparse.Namespace): Arguments
         num_classes (int): Number of classes in the dataset
     """
+    visualize = False
 
     def __init__(self, num_classes, alpha, p=1.0, inplace=False):
         if not (num_classes > 0):

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -1,14 +1,14 @@
+import math
 import random
 from collections.abc import Sequence
-import math
 from typing import Dict, Optional
 
 import numpy as np
 import PIL.Image as Image
 import torch
-from torch.nn import functional as F_torch
 import torchvision.transforms as T
 import torchvision.transforms.functional as F
+from torch.nn import functional as F_torch
 from torchvision.transforms.functional import InterpolationMode
 
 BBOX_CROP_KEEP_THRESHOLD = 0.2
@@ -368,7 +368,7 @@ class RandomMixup:
             raise ValueError("Alpha param can't be zero.")
         if not (0.0 < p <= 1.0):
             raise ValueError("MixUp probability should be between 0 and 1, where 1 is inclusive")
-        
+
         self.num_classes = num_classes
         self.alpha = alpha
         self.p = p
@@ -441,7 +441,7 @@ class RandomCutmix:
             raise ValueError("Alpha param can't be zero.")
         if not (0.0 < p <= 1.0):
             raise ValueError("CutMix probability should be between 0 and 1, where 1 is inclusive")
-        
+
         self.num_classes = num_classes
         self.alpha = alpha
         self.p = p

--- a/src/netspresso_trainer/dataloaders/augmentation/registry.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/registry.py
@@ -1,6 +1,6 @@
 from typing import Callable, Dict
 
-from .custom import ColorJitter, Pad, RandomCrop, RandomHorizontalFlip, RandomResizedCrop, RandomVerticalFlip, Resize, RandomMixup
+from .custom import ColorJitter, Pad, RandomCrop, RandomHorizontalFlip, RandomResizedCrop, RandomVerticalFlip, Resize, RandomMixup, RandomCutmix
 TRANSFORM_DICT: Dict[str, Callable] = {
     'colorjitter': ColorJitter,
     'pad': Pad,
@@ -10,4 +10,5 @@ TRANSFORM_DICT: Dict[str, Callable] = {
     'randomverticalflip': RandomVerticalFlip,
     'resize': Resize,
     'mixup': RandomMixup,
+    'cutmix': RandomCutmix
 }

--- a/src/netspresso_trainer/dataloaders/augmentation/registry.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/registry.py
@@ -1,6 +1,17 @@
 from typing import Callable, Dict
 
-from .custom import ColorJitter, Pad, RandomCrop, RandomHorizontalFlip, RandomResizedCrop, RandomVerticalFlip, Resize, RandomMixup, RandomCutmix
+from .custom import (
+    ColorJitter,
+    Pad,
+    RandomCrop,
+    RandomCutmix,
+    RandomHorizontalFlip,
+    RandomMixup,
+    RandomResizedCrop,
+    RandomVerticalFlip,
+    Resize,
+)
+
 TRANSFORM_DICT: Dict[str, Callable] = {
     'colorjitter': ColorJitter,
     'pad': Pad,

--- a/src/netspresso_trainer/dataloaders/augmentation/registry.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/registry.py
@@ -1,7 +1,6 @@
 from typing import Callable, Dict
 
-from .custom import ColorJitter, Pad, RandomCrop, RandomHorizontalFlip, RandomResizedCrop, RandomVerticalFlip, Resize
-
+from .custom import ColorJitter, Pad, RandomCrop, RandomHorizontalFlip, RandomResizedCrop, RandomVerticalFlip, Resize, RandomMixup
 TRANSFORM_DICT: Dict[str, Callable] = {
     'colorjitter': ColorJitter,
     'pad': Pad,
@@ -10,4 +9,5 @@ TRANSFORM_DICT: Dict[str, Callable] = {
     'randomhorizontalflip': RandomHorizontalFlip,
     'randomverticalflip': RandomVerticalFlip,
     'resize': Resize,
+    'mixup': RandomMixup,
 }

--- a/src/netspresso_trainer/dataloaders/augmentation/transforms.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/transforms.py
@@ -31,7 +31,7 @@ def generate_edge(label: np.ndarray) -> Image.Image:
 def transforms_custom_train(conf_augmentation):
     assert conf_augmentation.img_size > 32
     preprocess = []
-    for augment in conf_augmentation.recipe:
+    for augment in conf_augmentation.transforms:
         name = augment.name.lower()
         augment_kwargs = list(augment.keys())
         augment_kwargs.remove('name')
@@ -58,7 +58,7 @@ def transforms_custom_eval(conf_augmentation):
 
 def train_transforms_pidnet(conf_augmentation):
     preprocess = []
-    for augment in conf_augmentation.recipe:
+    for augment in conf_augmentation.transforms:
         name = augment.name.lower()
         augment_kwargs = list(augment.keys())
         augment_kwargs.remove('name')

--- a/src/netspresso_trainer/dataloaders/builder.py
+++ b/src/netspresso_trainer/dataloaders/builder.py
@@ -103,9 +103,9 @@ def build_dataset(conf_data, conf_augmentation, task: str, model_name: str):
 def build_dataloader(conf, task: str, model_name: str, train_dataset, eval_dataset, profile=False):
 
     if task == 'classification':
-        if hasattr(conf.augmentation, 'mix_transform'):
+        if hasattr(conf.augmentation, 'mix_transforms'):
             mix_transforms = []
-            for mix_transform_conf in conf.augmentation.mix_transform:
+            for mix_transform_conf in conf.augmentation.mix_transforms:
                 name = mix_transform_conf.name.lower()
 
                 mix_kwargs = list(mix_transform_conf.keys())

--- a/src/netspresso_trainer/dataloaders/builder.py
+++ b/src/netspresso_trainer/dataloaders/builder.py
@@ -1,6 +1,6 @@
-from functools import partial
 import logging
 import os
+from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional, Type, Union
 

--- a/src/netspresso_trainer/dataloaders/classification/__init__.py
+++ b/src/netspresso_trainer/dataloaders/classification/__init__.py
@@ -1,3 +1,3 @@
-from .dataset import ClassficationDataSampler
+from .dataset import ClassficationDataSampler, classification_mix_collate_fn
 from .huggingface import ClassificationHFDataset
 from .local import ClassificationCustomDataset

--- a/src/netspresso_trainer/dataloaders/classification/__init__.py
+++ b/src/netspresso_trainer/dataloaders/classification/__init__.py
@@ -1,3 +1,3 @@
-from .dataset import ClassficationDataSampler, classification_mix_collate_fn
+from .dataset import ClassficationDataSampler, classification_mix_collate_fn, classification_onehot_collate_fn
 from .huggingface import ClassificationHFDataset
 from .local import ClassificationCustomDataset

--- a/src/netspresso_trainer/dataloaders/classification/dataset.py
+++ b/src/netspresso_trainer/dataloaders/classification/dataset.py
@@ -1,9 +1,9 @@
 import csv
 import logging
+import random
 from collections import Counter
 from itertools import chain
 from pathlib import Path
-import random
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch

--- a/src/netspresso_trainer/dataloaders/classification/dataset.py
+++ b/src/netspresso_trainer/dataloaders/classification/dataset.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from omegaconf import DictConfig
+from torch.nn import functional as F
 from torch.utils.data import random_split
 
 from ..base import BaseDataSampler
@@ -82,6 +83,21 @@ def classification_mix_collate_fn(original_batch, mix_transforms):
 
     _mix_transform = random.choice(mix_transforms)
     images, target = _mix_transform(images, target)
+
+    outputs = (images, target)
+    return outputs
+
+
+def classification_onehot_collate_fn(original_batch, num_classes):
+    images = []
+    target = []
+    for data_sample in original_batch:
+        images.append(data_sample[0])
+        target.append(data_sample[1])
+
+    images = torch.stack(images, dim=0)
+    target = torch.tensor(target, dtype=torch.long)
+    target = F.one_hot(target, num_classes=num_classes).to(dtype=images.dtype)
 
     outputs = (images, target)
     return outputs

--- a/src/netspresso_trainer/dataloaders/classification/dataset.py
+++ b/src/netspresso_trainer/dataloaders/classification/dataset.py
@@ -3,6 +3,7 @@ import logging
 from collections import Counter
 from itertools import chain
 from pathlib import Path
+import random
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -67,6 +68,24 @@ def is_file_dict(image_dir: Union[Path, str], file_or_dir_to_idx):
     assert len(file_candidates) != 0, f"Unknown label format! Is there any something file like {file_or_dir} ?"
 
     return True
+
+
+def classification_mix_collate_fn(original_batch, mix_transforms):
+    images = []
+    target = []
+    for data_sample in original_batch:
+        images.append(data_sample[0])
+        target.append(data_sample[1])
+
+    images = torch.stack(images, dim=0)
+    target = torch.tensor(target, dtype=torch.long)
+
+    _mix_transform = random.choice(mix_transforms)
+    images, target = _mix_transform(images, target)
+
+    outputs = (images, target)
+    return outputs
+
 
 class ClassficationDataSampler(BaseDataSampler):
     def __init__(self, conf_data, train_valid_split_ratio):

--- a/src/netspresso_trainer/pipelines/classification.py
+++ b/src/netspresso_trainer/pipelines/classification.py
@@ -28,6 +28,8 @@ class ClassificationPipeline(BasePipeline):
 
         out = self.model(images)
         self.loss_factory.calc(out, target, phase='train')
+        if target.dim() > 1: # Soft label to label number
+            target = torch.argmax(target, dim=-1)
         self.metric_factory.calc(out['pred'], target, phase='train')
 
         self.loss_factory.backward()
@@ -44,6 +46,8 @@ class ClassificationPipeline(BasePipeline):
 
         out = self.model(images)
         self.loss_factory.calc(out, target, phase='valid')
+        if target.dim() > 1: # Soft label to label number
+            target = torch.argmax(target, dim=-1)
         self.metric_factory.calc(out['pred'], target, phase='valid')
 
         if self.conf.distributed:

--- a/tools/config_test.py
+++ b/tools/config_test.py
@@ -35,12 +35,12 @@ if __name__ == "__main__":
     
     # OK: update value of subclass in the main dataclass
     cfg_new: TrainerConfig = deepcopy(cfg)
-    cfg_new.augmentation.recipe[-1].saturation = 0.0
+    cfg_new.augmentation.transforms[-1].saturation = 0.0
     # print(OmegaConf.to_yaml(OmegaConf.structured(cfg_new)))
     
     # OK: update value from OmegaConf Config
     config_new: TrainerConfig = deepcopy(config)
-    cfg_new.augmentation.recipe[-1].hue = 0.5
+    cfg_new.augmentation.transforms[-1].hue = 0.5
     # print(OmegaConf.to_yaml(config_new))
 
 


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #215

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add `cutmix` and `mixup` augmentation for classification task
- Since `cutmix` and `mixup` needs different samples, they are applied in `collate_fn`
- To distinguish with existing transform functions, `mixup` and `cutmix` added as `mix_transform`

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 