### PR TITLE
Fix default criterion value of classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## Bug Fixes:
 
 - Fix PIDNet model dataclass task field by `@illian01` in [PR 220](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/220)
+- Fix default criterion value of classification `@illian01` in [PR 238](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/238)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/cfg/model.py
+++ b/src/netspresso_trainer/cfg/model.py
@@ -306,7 +306,7 @@ class ClassificationEfficientFormerModelConfig(ModelConfig):
         head={"name": "fc"}
     ))
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "label_smoothing_cross_entropy", "smoothing": 0.1, "weight": None}
+        {"criterion": "cross_entropy", "smoothing": 0.1, "weight": None}
     ])
 
 
@@ -343,7 +343,7 @@ class ClassificationMobileNetV3ModelConfig(ModelConfig):
         head={"name": "fc"}
     ))
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "label_smoothing_cross_entropy", "smoothing": 0.1, "weight": None}
+        {"criterion": "cross_entropy", "smoothing": 0.1, "weight": None}
     ])
 
 
@@ -367,7 +367,7 @@ class ClassificationMobileViTModelConfig(ModelConfig):
         head={"name": "fc"}
     ))
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "label_smoothing_cross_entropy", "smoothing": 0.1, "weight": None}
+        {"criterion": "cross_entropy", "smoothing": 0.1, "weight": None}
     ])
 
 
@@ -391,7 +391,7 @@ class ClassificationResNetModelConfig(ModelConfig):
         head={"name": "fc"}
     ))
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "label_smoothing_cross_entropy", "smoothing": 0.1, "weight": None}
+        {"criterion": "cross_entropy", "smoothing": 0.1, "weight": None}
     ])
 
 
@@ -415,7 +415,7 @@ class ClassificationSegFormerModelConfig(ModelConfig):
         head={"name": "fc"}
     ))
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "label_smoothing_cross_entropy", "smoothing": 0.1, "weight": None}
+        {"criterion": "cross_entropy", "smoothing": 0.1, "weight": None}
     ])
 
 
@@ -439,6 +439,6 @@ class ClassificationViTModelConfig(ModelConfig):
         head={"name": "fc"}
     ))
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "label_smoothing_cross_entropy", "smoothing": 0.1, "weight": None}
+        {"criterion": "cross_entropy", "smoothing": 0.1, "weight": None}
     ])
 


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #233 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Fix default criterion value of classification

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 