### PR TITLE
Change extensions of model checkpoint and training summary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ __pycache__/
 *.whl
 *.tar
 *.gz
+*.json
+*.zip
+*.safetensors
 
 **/*/exp/
 **/*/events*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ## Breaking Changes:
 
--
+- Provide pytorch state dict with `.safetensors` and training summary with `.json` for a better utilization by `@deepkyu` in [PR 262](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/262)
 
 ## Other Changes:
 

--- a/config/model/efficientformer/efficientformer-l1-classification.yaml
+++ b/config/model/efficientformer/efficientformer-l1-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: efficientformer_l1
-  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.pth
+  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/efficientformer/efficientformer-l1-detection.yaml
+++ b/config/model/efficientformer/efficientformer-l1-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: efficientformer_l1
-  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.pth
+  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/efficientformer/efficientformer-l1-segmentation.yaml
+++ b/config/model/efficientformer/efficientformer-l1-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: efficientformer_l1
-  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.pth
+  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-l-classification.yaml
+++ b/config/model/mixnet/mixnet-l-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mixnet_l
-  checkpoint: ./weights/mixnet/mixnet_l.pth
+  checkpoint: ./weights/mixnet/mixnet_l.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mixnet_l
-  checkpoint: ./weights/mixnet/mixnet_l.pth
+  checkpoint: ./weights/mixnet/mixnet_l.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-l-segmentation.yaml
+++ b/config/model/mixnet/mixnet-l-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mixnet_l
-  checkpoint: ./weights/mixnet/mixnet_l.pth
+  checkpoint: ./weights/mixnet/mixnet_l.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-m-classification.yaml
+++ b/config/model/mixnet/mixnet-m-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mixnet_m
-  checkpoint: ./weights/mixnet/mixnet_m.pth
+  checkpoint: ./weights/mixnet/mixnet_m.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mixnet_m
-  checkpoint: ./weights/mixnet/mixnet_m.pth
+  checkpoint: ./weights/mixnet/mixnet_m.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-m-segmentation.yaml
+++ b/config/model/mixnet/mixnet-m-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mixnet_m
-  checkpoint: ./weights/mixnet/mixnet_m.pth
+  checkpoint: ./weights/mixnet/mixnet_m.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-s-classification.yaml
+++ b/config/model/mixnet/mixnet-s-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mixnet_s
-  checkpoint: ./weights/mixnet/mixnet_s.pth
+  checkpoint: ./weights/mixnet/mixnet_s.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mixnet_s
-  checkpoint: ./weights/mixnet/mixnet_s.pth
+  checkpoint: ./weights/mixnet/mixnet_s.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mixnet/mixnet-s-segmentation.yaml
+++ b/config/model/mixnet/mixnet-s-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mixnet_s
-  checkpoint: ./weights/mixnet/mixnet_s.pth
+  checkpoint: ./weights/mixnet/mixnet_s.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mobilenet_v3_small
-  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.pth
+  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mobilenet_v3_small
-  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.pth
+  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mobilenetv3/mobilenetv3-small-segmentation.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mobilenet_v3_small
-  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.pth
+  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/mobilevit/mobilevit-s-classification.yaml
+++ b/config/model/mobilevit/mobilevit-s-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mobilevit_s
-  checkpoint: ./weights/mobilevit/mobilevit_s.pth
+  checkpoint: ./weights/mobilevit/mobilevit_s.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/pidnet/pidnet-s-segmentation.yaml
+++ b/config/model/pidnet/pidnet-s-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: pidnet_s
-  checkpoint: ./weights/pidnet/pidnet_s.pth
+  checkpoint: ./weights/pidnet/pidnet_s.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/resnet/resnet50-classification.yaml
+++ b/config/model/resnet/resnet50-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: resnet50
-  checkpoint: ./weights/resnet/resnet50.pth
+  checkpoint: ./weights/resnet/resnet50.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: resnet50
-  checkpoint: ./weights/resnet/resnet50.pth
+  checkpoint: ./weights/resnet/resnet50.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/resnet/resnet50-segmentation.yaml
+++ b/config/model/resnet/resnet50-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: resnet50
-  checkpoint: ./weights/resnet/resnet50.pth
+  checkpoint: ./weights/resnet/resnet50.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/segformer/segformer-classification.yaml
+++ b/config/model/segformer/segformer-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: segformer
-  checkpoint: ./weights/segformer/segformer.pth
+  checkpoint: ./weights/segformer/segformer.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/segformer/segformer-detection.yaml
+++ b/config/model/segformer/segformer-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: segformer
-  checkpoint: ./weights/segformer/segformer.pth
+  checkpoint: ./weights/segformer/segformer.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/segformer/segformer-segmentation.yaml
+++ b/config/model/segformer/segformer-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: segformer
-  checkpoint: ./weights/segformer/segformer.pth
+  checkpoint: ./weights/segformer/segformer.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/vit/vit-classification.yaml
+++ b/config/model/vit/vit-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: vit_tiny
-  checkpoint: ./weights/vit/vit-tiny.pth
+  checkpoint: ./weights/vit/vit-tiny.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/config/model/yolox/yolox-detection.yaml
+++ b/config/model/yolox/yolox-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: yolox_s
-  checkpoint: ./weights/yolox/yolox_s.pth
+  checkpoint: ./weights/yolox/yolox_s.safetensors
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
   freeze_backbone: False

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ omegaconf
 opencv-python
 tensorboard
 fvcore
+safetensors

--- a/src/netspresso_trainer/cfg/model.py
+++ b/src/netspresso_trainer/cfg/model.py
@@ -520,7 +520,7 @@ class CSPDarkNetSmallArchitectureConfig(ArchitectureConfig):
 class ClassificationEfficientFormerModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "efficientformer_l1"
-    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: EfficientFormerArchitectureConfig(
         head={
             "name": "fc",
@@ -539,7 +539,7 @@ class ClassificationEfficientFormerModelConfig(ModelConfig):
 class SegmentationEfficientFormerModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "efficientformer_l1"
-    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: EfficientFormerArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -558,7 +558,7 @@ class SegmentationEfficientFormerModelConfig(ModelConfig):
 class DetectionEfficientFormerModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "efficientformer_l1"
-    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: EfficientFormerArchitectureConfig(
         neck={
             "name": "fpn",
@@ -597,7 +597,7 @@ class DetectionEfficientFormerModelConfig(ModelConfig):
 class ClassificationMobileNetV3ModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mobilenet_v3_small"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileNetV3ArchitectureConfig(
         head={
             "name": "fc",
@@ -616,7 +616,7 @@ class ClassificationMobileNetV3ModelConfig(ModelConfig):
 class SegmentationMobileNetV3ModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mobilenet_v3_small"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileNetV3ArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -635,7 +635,7 @@ class SegmentationMobileNetV3ModelConfig(ModelConfig):
 class DetectionMobileNetV3ModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mobilenet_v3_small"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileNetV3ArchitectureConfig(
         neck={
             "name": "fpn",
@@ -674,7 +674,7 @@ class DetectionMobileNetV3ModelConfig(ModelConfig):
 class ClassificationMobileViTModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mobilevit_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilevit/mobilevit_s.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilevit/mobilevit_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileViTArchitectureConfig(
         head={
             "name": "fc",
@@ -693,7 +693,7 @@ class ClassificationMobileViTModelConfig(ModelConfig):
 class PIDNetModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "pidnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/pidnet/pidnet_s.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/pidnet/pidnet_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: PIDNetArchitectureConfig())
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
         {"criterion": "pidnet_cross_entropy", "ignore_index": 255, "weight": None},
@@ -706,7 +706,7 @@ class PIDNetModelConfig(ModelConfig):
 class ClassificationResNetModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "resnet50"
-    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ResNetArchitectureConfig(
         head={
             "name": "fc",
@@ -725,7 +725,7 @@ class ClassificationResNetModelConfig(ModelConfig):
 class SegmentationResNetModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "resnet50"
-    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ResNetArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -744,7 +744,7 @@ class SegmentationResNetModelConfig(ModelConfig):
 class DetectionResNetModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "resnet50"
-    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ResNetArchitectureConfig(
         neck={
             "name": "fpn",
@@ -783,7 +783,7 @@ class DetectionResNetModelConfig(ModelConfig):
 class ClassificationSegFormerModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "segformer"
-    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: SegFormerArchitectureConfig(
         head={
             "name": "fc",
@@ -802,7 +802,7 @@ class ClassificationSegFormerModelConfig(ModelConfig):
 class SegmentationSegFormerModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "segformer"
-    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: SegFormerArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -821,7 +821,7 @@ class SegmentationSegFormerModelConfig(ModelConfig):
 class DetectionSegFormerModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "segformer"
-    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: SegFormerArchitectureConfig(
         neck={
             "name": "fpn",
@@ -860,7 +860,7 @@ class DetectionSegFormerModelConfig(ModelConfig):
 class ClassificationViTModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "vit_tiny"
-    checkpoint: Optional[Union[Path, str]] = "./weights/vit/vit-tiny.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/vit/vit-tiny.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ViTArchitectureConfig(
         head={
             "name": "fc",
@@ -879,7 +879,7 @@ class ClassificationViTModelConfig(ModelConfig):
 class DetectionYoloXModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "yolox_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/yolox/yolox_s.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/yolox/yolox_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: CSPDarkNetSmallArchitectureConfig(
         neck={
             "name": "pafpn",
@@ -909,7 +909,7 @@ class DetectionYoloXModelConfig(ModelConfig):
 class ClassificationMixNetSmallModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mixnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetSmallArchitectureConfig(
         head={
             "name": "fc",
@@ -928,7 +928,7 @@ class ClassificationMixNetSmallModelConfig(ModelConfig):
 class SegmentationMixNetSmallModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mixnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetSmallArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -947,7 +947,7 @@ class SegmentationMixNetSmallModelConfig(ModelConfig):
 class DetectionMixNetSmallModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mixnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetSmallArchitectureConfig(
         neck={
             "name": "fpn",
@@ -986,7 +986,7 @@ class DetectionMixNetSmallModelConfig(ModelConfig):
 class ClassificationMixNetMediumModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mixnet_m"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetMediumArchitectureConfig(
         head={
             "name": "fc",
@@ -1005,7 +1005,7 @@ class ClassificationMixNetMediumModelConfig(ModelConfig):
 class SegmentationMixNetMediumModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mixnet_m"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetMediumArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -1024,7 +1024,7 @@ class SegmentationMixNetMediumModelConfig(ModelConfig):
 class DetectionMixNetMediumModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mixnet_m"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetMediumArchitectureConfig(
         neck={
             "name": "fpn",
@@ -1063,7 +1063,7 @@ class DetectionMixNetMediumModelConfig(ModelConfig):
 class ClassificationMixNetLargeModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mixnet_l"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetLargeArchitectureConfig(
         head={
             "name": "fc",
@@ -1082,7 +1082,7 @@ class ClassificationMixNetLargeModelConfig(ModelConfig):
 class SegmentationMixNetLargeModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mixnet_l"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetLargeArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -1101,7 +1101,7 @@ class SegmentationMixNetLargeModelConfig(ModelConfig):
 class DetectionMixNetLargeModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mixnet_l"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.pth"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetLargeArchitectureConfig(
         neck={
             "name": "fpn",

--- a/src/netspresso_trainer/models/utils.py
+++ b/src/netspresso_trainer/models/utils.py
@@ -8,6 +8,8 @@ import torch.nn as nn
 from torch import Tensor
 from torch.fx.proxy import Proxy
 
+from ..utils.checkpoint import load_checkpoint
+
 logger = logging.getLogger(__name__)
 
 FXTensorType = Union[Tensor, Proxy]
@@ -86,7 +88,7 @@ def load_from_checkpoint(
                 f"model_name {model_name} in path {model_checkpoint} is not valid name!"
             model_checkpoint = download_model_checkpoint(model_checkpoint, model_name)
 
-        model_state_dict = torch.load(model_checkpoint, map_location='cpu')
+        model_state_dict = load_checkpoint(model_checkpoint)
         missing_keys, unexpected_keys = model.load_state_dict(model_state_dict, strict=False)
 
         if len(missing_keys) != 0:

--- a/src/netspresso_trainer/models/utils.py
+++ b/src/netspresso_trainer/models/utils.py
@@ -16,17 +16,17 @@ FXTensorType = Union[Tensor, Proxy]
 FXTensorListType = Union[List[Tensor], List[Proxy]]
 
 MODEL_CHECKPOINT_URL_DICT = {
-    'resnet50': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/resnet/resnet50.pth",
-    'mobilenet_v3_small': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilenetv3/mobilenet_v3_small.pth",
-    'segformer': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/segformer/segformer.pth",
-    'mobilevit_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilevit/mobilevit_s.pth",
-    'vit_tiny': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/vit/vit-tiny.pth",
-    'efficientformer_l1': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/efficientformer/efficientformer_l1_1000d.pth",
-    'mixnet_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_s.pth",
-    'mixnet_m': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_m.pth",
-    'mixnet_l': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_l.pth",
-    'pidnet_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/pidnet/pidnet_s.pth",
-    'yolox_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/cspdarknet/yolox_s.pth",
+    'resnet50': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/resnet/resnet50.safetensors",
+    'mobilenet_v3_small': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilenetv3/mobilenet_v3_small.safetensors",
+    'segformer': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/segformer/segformer.safetensors",
+    'mobilevit_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilevit/mobilevit_s.safetensors",
+    'vit_tiny': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/vit/vit-tiny.safetensors",
+    'efficientformer_l1': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/efficientformer/efficientformer_l1_1000d.safetensors",
+    'mixnet_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_s.safetensors",
+    'mixnet_m': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_m.safetensors",
+    'mixnet_l': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_l.safetensors",
+    'pidnet_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/pidnet/pidnet_s.safetensors",
+    'yolox_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/cspdarknet/yolox_s.safetensors",
 }
 
 

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -331,8 +332,9 @@ class BasePipeline(ABC):
             training_summary.params = params
 
         result_dir = self.train_logger.result_dir
-        summary_path = Path(result_dir) / "training_summary.ckpt"
-        torch.save(asdict(training_summary), summary_path)
+        summary_path = Path(result_dir) / "training_summary.json"
+        with open(summary_path, 'w') as f:
+            json.dump(asdict(training_summary), f, indent=4)
         logger.info(f"Model training summary saved at {str(summary_path)}")
 
     def profile_one_epoch(self):

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -18,6 +18,7 @@ from ..metrics import build_metrics
 from ..optimizers import build_optimizer
 from ..postprocessors import build_postprocessor
 from ..schedulers import build_scheduler
+from ..utils.checkpoint import load_checkpoint, save_checkpoint
 from ..utils.fx import save_graphmodule
 from ..utils.logger import add_file_handler, yaml_for_logging
 from ..utils.onnx import save_onnx
@@ -294,11 +295,13 @@ class BasePipeline(ABC):
                 torch.save(model, best_model_path.with_suffix(".pt"))
                 logger.info(f"Best model saved at {str(best_model_path.with_suffix('.pt'))}")
             return
-        torch.save(model.state_dict(), model_path.with_suffix(".pth"))
-        logger.debug(f"PyTorch model saved at {str(model_path.with_suffix('.pth'))}")
+        pytorch_model_state_dict_path = model_path.with_suffix(".safetensors")
+        save_checkpoint(model.state_dict(), pytorch_model_state_dict_path)
+        logger.debug(f"PyTorch model saved at {str(pytorch_model_state_dict_path)}")
         if save_best_model:
-            torch.save(model.state_dict(), best_model_path.with_suffix(".pth"))
-            logger.info(f"Best model saved at {str(best_model_path.with_suffix('.pth'))}")
+            pytorch_best_model_state_dict_path = best_model_path.with_suffix(".safetensors")
+            save_checkpoint(model.state_dict(), pytorch_best_model_state_dict_path)
+            logger.info(f"Best model saved at {str(pytorch_best_model_state_dict_path)}")
 
             try:
                 save_onnx(model, best_model_path.with_suffix(".onnx"), sample_input=self.sample_input.type(self.save_dtype))

--- a/src/netspresso_trainer/utils/checkpoint.py
+++ b/src/netspresso_trainer/utils/checkpoint.py
@@ -1,14 +1,15 @@
-from typing import Union
-from pathlib import Path
 import warnings
+from pathlib import Path
+from typing import Union
 
 import torch
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+
 def _validate_file(file_path: Path):
     file_path = Path(file_path)
-    
+
     extension = file_path.suffix
     supporting_extensions = ['.pth', '.pt', '.ckpt', '.safetensors']
     assert extension in supporting_extensions, f"The checkpoint format should be one of {supporting_extensions}! The given file is {file_path}."
@@ -17,14 +18,14 @@ def _validate_file(file_path: Path):
 
 def load_checkpoint(f: Union[str, Path]):
     file_path, extension = _validate_file(f)
-    
+
     if extension == '.safetensors':
         state_dict = {}
         with safe_open(str(file_path), framework="pt", device='cpu') as f:
-            for k in f.keys():
+            for k in f:
                 state_dict[k] = f.get_tensor(k)
         return state_dict
-    
+
     state_dict = torch.load(file_path, map_location='cpu')
     return state_dict
 
@@ -34,5 +35,5 @@ def save_checkpoint(obj_dict, f: Union[str, Path]) -> None:
 
     if extension == '.safetensors':
         save_file(obj_dict, str(file_path))
-    
-    state_dict = torch.save(obj_dict, file_path)
+
+    torch.save(obj_dict, file_path)

--- a/src/netspresso_trainer/utils/checkpoint.py
+++ b/src/netspresso_trainer/utils/checkpoint.py
@@ -1,0 +1,38 @@
+from typing import Union
+from pathlib import Path
+import warnings
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+def _validate_file(file_path: Path):
+    file_path = Path(file_path)
+    
+    extension = file_path.suffix
+    supporting_extensions = ['.pth', '.pt', '.ckpt', '.safetensors']
+    assert extension in supporting_extensions, f"The checkpoint format should be one of {supporting_extensions}! The given file is {file_path}."
+    return file_path, extension
+
+
+def load_checkpoint(f: Union[str, Path]):
+    file_path, extension = _validate_file(f)
+    
+    if extension == '.safetensors':
+        state_dict = {}
+        with safe_open(str(file_path), framework="pt", device='cpu') as f:
+            for k in f.keys():
+                state_dict[k] = f.get_tensor(k)
+        return state_dict
+    
+    state_dict = torch.load(file_path, map_location='cpu')
+    return state_dict
+
+
+def save_checkpoint(obj_dict, f: Union[str, Path]) -> None:
+    file_path, extension = _validate_file(f)
+
+    if extension == '.safetensors':
+        save_file(obj_dict, str(file_path))
+    
+    state_dict = torch.save(obj_dict, file_path)

--- a/src/netspresso_trainer/utils/checkpoint.py
+++ b/src/netspresso_trainer/utils/checkpoint.py
@@ -22,7 +22,8 @@ def load_checkpoint(f: Union[str, Path]):
     if extension == '.safetensors':
         state_dict = {}
         with safe_open(str(file_path), framework="pt", device='cpu') as f:
-            for k in f:
+            state_dict_keys = f.keys()
+            for k in state_dict_keys:
                 state_dict[k] = f.get_tensor(k)
         return state_dict
 

--- a/tools/checkpoint_converter.py
+++ b/tools/checkpoint_converter.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import torch
+from safetensors.torch import save_file
 from omegaconf import ListConfig, OmegaConf
 
 
@@ -67,14 +68,14 @@ def convert_state_dict_to_model(yaml_path, model, state_dict):
     print(f"no_match_layers: \n{no_match_layers[:]}")
     print(f"NO MATCH COUNT: {len(no_match_layers)}")
     model.load_state_dict(dict(extracted_state_dict), strict=False)
-    _save_extracted_state_dict(extracted_state_dict, "result.pth")
+    _save_extracted_state_dict(extracted_state_dict, "result.safetensors")
 
     print("Complete!")
     return model
 
 
 def _save_extracted_state_dict(extracted_state_dict, f):
-    torch.save(extracted_state_dict, f)
+    save_file(extracted_state_dict, f)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #261

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Replace `.pth` state dict for model with `.safetensors`
  - Backward-support: `.pth` automatically redirects to `.safetensors` path(or url)
- training summary are provided with `.json` format 

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 