### PR TITLE
Remove `num_anchors` field in RetinaNet head configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Refactoring for detection models by `@illian01` in [PR 260](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/260)
 - Equalize logging format with `PyNetsPresso` by `@deepkyu` in [PR 263](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/263)
-- Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265)
+- Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265), [PR 266](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/266)
 
 # v0.0.10
 

--- a/config/model/efficientformer/efficientformer-l1-detection.yaml
+++ b/config/model/efficientformer/efficientformer-l1-detection.yaml
@@ -58,7 +58,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -73,7 +73,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -73,7 +73,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -73,7 +73,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -61,7 +61,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -46,7 +46,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/config/model/segformer/segformer-detection.yaml
+++ b/config/model/segformer/segformer-detection.yaml
@@ -58,7 +58,6 @@ model:
       params:
         anchor_sizes: [[64,], [128,], [256,], [512,]]
         aspect_ratios: [0.5, 1.0, 2.0]
-        num_anchors: 3
         norm_layer: batch_norm
         # postprocessor - decode
         topk_candidates: 1000

--- a/src/netspresso_trainer/cfg/model.py
+++ b/src/netspresso_trainer/cfg/model.py
@@ -577,7 +577,6 @@ class DetectionEfficientFormerModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,
@@ -654,7 +653,6 @@ class DetectionMobileNetV3ModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,
@@ -763,7 +761,6 @@ class DetectionResNetModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,
@@ -840,7 +837,6 @@ class DetectionSegFormerModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,
@@ -966,7 +962,6 @@ class DetectionMixNetSmallModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,
@@ -1043,7 +1038,6 @@ class DetectionMixNetMediumModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,
@@ -1120,7 +1114,6 @@ class DetectionMixNetLargeModelConfig(ModelConfig):
                 # Anchor parameters
                 "anchor_sizes": [[64,], [128,], [256,], [512,]],
                 "aspect_ratios": [0.5, 1.0, 2.0],
-                "num_anchors": 3,
                 "norm_layer": "batch_norm",
                 # postprocessor - decode
                 "topk_candidates": 1000,

--- a/src/netspresso_trainer/models/heads/detection/experimental/retinanet.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/retinanet.py
@@ -28,12 +28,12 @@ class RetinaNetHead(nn.Module):
         anchor_sizes = params.anchor_sizes
         aspect_ratios = params.aspect_ratios
 
-        num_anchors = params.num_anchors
         norm_layer = params.norm_layer
 
         aspect_ratios = (aspect_ratios,) * len(anchor_sizes)
         # TODO: Temporarily use hard-coded img_size
         self.anchor_generator = AnchorGenerator(anchor_sizes, aspect_ratios, (512, 512)) 
+        num_anchors = self.anchor_generator.num_anchors_per_location()[0]
 
         self.classification_head = RetinaNetClassificationHead(
             in_channels, num_anchors, num_classes, norm_layer=norm_layer


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: ~

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Remove `num_anchors` field in `RetinaNet` head configuration
- refer [torchvision code](https://github.com/pytorch/vision/blob/e12d200c97d7aab668b976e92b46513c9ca7a0d8/torchvision/models/detection/retinanet.py#L455)

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 