### PR TITLE
Combine `PIDNetLoss` and fix all loss module to receive `target` as `Dict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 - Refactoring for detection models by `@illian01` in [PR 260](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/260)
 - Equalize logging format with `PyNetsPresso` by `@deepkyu` in [PR 263](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/263)
-- Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265), [PR 266](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/266)
+- Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265), [PR 266](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/266), [PR 267](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/267)
 
 # v0.0.10
 

--- a/config/model/pidnet/pidnet-s-segmentation.yaml
+++ b/config/model/pidnet/pidnet-s-segmentation.yaml
@@ -16,11 +16,6 @@ model:
     backbone: ~
     head: ~
   losses:
-    - criterion: pidnet_cross_entropy
-      weight: ~
-      ignore_index: 255
-    - criterion: boundary_loss
-      weight: 20.0
-    - criterion: pidnet_cross_entropy_with_boundary
+    - criterion: pidnet_loss
       weight: ~
       ignore_index: 255

--- a/src/netspresso_trainer/cfg/model.py
+++ b/src/netspresso_trainer/cfg/model.py
@@ -694,9 +694,7 @@ class PIDNetModelConfig(ModelConfig):
     checkpoint: Optional[Union[Path, str]] = "./weights/pidnet/pidnet_s.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: PIDNetArchitectureConfig())
     losses: List[Dict[str, Any]] = field(default_factory=lambda: [
-        {"criterion": "pidnet_cross_entropy", "ignore_index": 255, "weight": None},
-        {"criterion": "boundary_loss", "weight": 20.0},
-        {"criterion": "pidnet_cross_entropy_with_boundary", "ignore_index": 255, "weight": None},
+        {"criterion": "pidnet_loss", "ignore_index": 255, "weight": None},
     ])
 
 

--- a/src/netspresso_trainer/losses/builder.py
+++ b/src/netspresso_trainer/losses/builder.py
@@ -45,8 +45,7 @@ class LossFactory:
         self._clear_step_start()
 
     def _assert_argument(self, kwargs):
-        if 'boundary_loss' in self.loss_func_dict:
-            assert 'bd_gt' in kwargs, "BoundaryLoss failed!"
+        pass
 
     def backward(self):
         assert not self._dirty_backward

--- a/src/netspresso_trainer/losses/builder.py
+++ b/src/netspresso_trainer/losses/builder.py
@@ -67,12 +67,11 @@ class LossFactory:
         phase = phase.lower()
         assert phase in PHASE_LIST, f"{phase} is not defined at our phase list ({PHASE_LIST})"
 
-        bd_gt = kwargs['bd_gt'] if 'bd_gt' in kwargs else None
         self._assert_argument(kwargs)
         self._clear_step_start()
 
         for loss_key, loss_func in self.loss_func_dict.items():
-            loss_val = loss_func(out, bd_gt) if loss_key == 'boundary_loss' else loss_func(out, target)
+            loss_val = loss_func(out, target)
             self.loss_val_per_epoch[phase][loss_key].update(loss_val.item())
             self.total_loss_for_backward += loss_val * self.loss_weight_dict[loss_key]
 

--- a/src/netspresso_trainer/losses/common.py
+++ b/src/netspresso_trainer/losses/common.py
@@ -13,8 +13,9 @@ class CrossEntropyLoss(nn.Module):
         self.loss_fn = nn.CrossEntropyLoss(weight=weight, size_average=size_average, ignore_index=ignore_index,
                                            reduce=reduce, reduction='mean', label_smoothing=label_smoothing)
 
-    def forward(self, out: Dict, target: torch.Tensor) -> torch.Tensor:
+    def forward(self, out: Dict, target: Dict) -> Dict:
         pred = out['pred']
+        target = target['target']
         loss = self.loss_fn(pred, target)
         return loss
 
@@ -25,8 +26,9 @@ class SigmoidFocalLoss(nn.Module):
         self.alpha = alpha
         self.gamma = gamma
 
-    def forward(self, out: Dict, target: torch.Tensor, reduction='mean'):
+    def forward(self, out: Dict, target: Dict, reduction='mean'):
         pred = out['pred']
+        target = target['target']
         assert pred.shape == target.shape, 'Tensor shapes of prediction and target must be same for SigmoidFocalLoss.'
 
         p = torch.sigmoid(pred)

--- a/src/netspresso_trainer/losses/detection/retinanet.py
+++ b/src/netspresso_trainer/losses/detection/retinanet.py
@@ -30,7 +30,7 @@ class RetinaNetLoss(nn.Module):
         # TODO: return as dict
         return cls_loss + box_loss
 
-    def forward(self, out: Dict, target: torch.Tensor) -> torch.Tensor:
+    def forward(self, out: Dict, target: Dict) -> torch.Tensor:
         matched_idxs = []
         anchors = out['anchors']
 
@@ -81,7 +81,7 @@ class RetinaNetClassificationLoss(nn.Module):
             losses.append(
                 self.focal_loss(
                     {'pred': cls_logits_per_image[valid_idxs_per_image]},
-                    gt_classes_target[valid_idxs_per_image],
+                    {'target': gt_classes_target[valid_idxs_per_image]},
                     reduction="sum",
                 )
                 / max(1, num_foreground)

--- a/src/netspresso_trainer/losses/registry.py
+++ b/src/netspresso_trainer/losses/registry.py
@@ -1,12 +1,10 @@
 from .common import CrossEntropyLoss, SigmoidFocalLoss
 from .detection import RetinaNetLoss, YOLOXLoss
-from .segmentation import BoundaryLoss, PIDNetBoundaryAwareCrossEntropy, PIDNetCrossEntropy
+from .segmentation import PIDNetLoss
 
 LOSS_DICT = {
     'cross_entropy': CrossEntropyLoss,
-    'pidnet_cross_entropy': PIDNetCrossEntropy,
-    'boundary_loss': BoundaryLoss,
-    'pidnet_cross_entropy_with_boundary': PIDNetBoundaryAwareCrossEntropy,
+    'pidnet_loss': PIDNetLoss,
     'yolox_loss': YOLOXLoss,
     'retinanet_loss': RetinaNetLoss,
     'focal_loss': SigmoidFocalLoss,

--- a/src/netspresso_trainer/losses/segmentation/__init__.py
+++ b/src/netspresso_trainer/losses/segmentation/__init__.py
@@ -1,1 +1,1 @@
-from .pidnet import BoundaryLoss, PIDNetBoundaryAwareCrossEntropy, PIDNetCrossEntropy
+from .pidnet import PIDNetLoss

--- a/src/netspresso_trainer/losses/segmentation/pidnet.py
+++ b/src/netspresso_trainer/losses/segmentation/pidnet.py
@@ -29,7 +29,8 @@ class PIDNetCrossEntropy(nn.Module):
 
         return self.loss_fn(out, target)
 
-    def forward(self, out: Dict, target: torch.Tensor):
+    def forward(self, out: Dict, target: Dict):
+        target = target['target']
 
         if self.boundary_aware:
             pred, extra_d = out['pred'], out['extra_d']
@@ -127,6 +128,7 @@ class BoundaryLoss(nn.Module):
 
         return loss
 
-    def forward(self, out: Dict, bd_gt: torch.Tensor) -> torch.Tensor:
+    def forward(self, out: Dict, target: Dict) -> torch.Tensor:
+        bd_gt = target['bd_gt']
         extra_d = out['extra_d']
         return self.weighted_bce(extra_d, bd_gt)

--- a/src/netspresso_trainer/losses/segmentation/pidnet.py
+++ b/src/netspresso_trainer/losses/segmentation/pidnet.py
@@ -132,3 +132,22 @@ class BoundaryLoss(nn.Module):
         bd_gt = target['bd_gt']
         extra_d = out['extra_d']
         return self.weighted_bce(extra_d, bd_gt)
+
+
+class PIDNetLoss(nn.Module):
+    def __init__(self, ignore_index=IGNORE_INDEX_NONE_VALUE, weight=None):
+        super().__init__()
+
+        self.cross_entropy_loss = PIDNetCrossEntropy(ignore_index=ignore_index)
+        self.boundary_loss = BoundaryLoss()
+        self.cross_entropy_with_boundary = PIDNetBoundaryAwareCrossEntropy(ignore_index=ignore_index)
+
+    def forward(self, out: Dict, target: Dict):
+
+        cross_entropy_loss = self.cross_entropy_loss(out, target)
+        boundary_loss = self.boundary_loss(out, target)
+        cross_entropy_loss_with_boundary = self.cross_entropy_with_boundary(out, target)
+
+        # TODO: return as dict
+        loss = cross_entropy_loss + 20 * boundary_loss + cross_entropy_loss_with_boundary
+        return loss


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Combine `PIDNetCrossEntropy`, `PIDNetBoundaryAwareCrossEntropy`, and `BoundaryLoss` as `PIDNetLoss`
- Fix all task loss target to have Dict type
  - `forward` method of loss module receive `target` parameter as `Dict`

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 