### PR TITLE
GPU ids with training configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Construct head by config file by `@illian01` in [PR 237](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/237)
 - Construct neck by config file by `@illian01` in [PR 249](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/249)
 - Add model: RetinaNet by `@illian01` in [PR 257](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/257)
+- Select `gpus` with `environment` configuration by `@deepkyu` in [PR 269](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/269)
 
 ## Bug Fixes:
 

--- a/config/environment.yaml
+++ b/config/environment.yaml
@@ -1,3 +1,3 @@
 environment: 
   num_workers: 4 
-  gpus: 0,1
+  gpus: 0

--- a/config/environment.yaml
+++ b/config/environment.yaml
@@ -1,2 +1,3 @@
 environment: 
   num_workers: 4 
+  gpus: 0,1

--- a/src/netspresso_trainer/cfg/environment.py
+++ b/src/netspresso_trainer/cfg/environment.py
@@ -4,3 +4,4 @@ from dataclasses import dataclass
 @dataclass
 class EnvironmentConfig:
     num_workers: int = 4
+    gpus: str = "0"

--- a/src/netspresso_trainer/trainer_inline.py
+++ b/src/netspresso_trainer/trainer_inline.py
@@ -1,12 +1,12 @@
 import os
 from pathlib import Path
-from typing import List, Literal, Union
+from typing import List, Literal, Optional, Union
 
 import torch
 from omegaconf import DictConfig, OmegaConf
 
 from netspresso_trainer.cfg import TrainerConfig
-from netspresso_trainer.trainer_cli import parse_gpu_ids, train_with_yaml_impl
+from netspresso_trainer.trainer_cli import get_gpus_from_parser_and_config, parse_gpu_ids, train_with_yaml_impl
 from netspresso_trainer.trainer_common import train_common
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
@@ -24,9 +24,15 @@ def export_config_as_yaml(config: TrainerConfig) -> str:
     return OmegaConf.to_yaml(conf)
 
 
-def train_with_config(gpus: str, config: TrainerConfig, log_level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO') -> None:
+def train_with_config(
+    config: TrainerConfig,
+    gpus: Optional[str] = None,
+    log_level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'] = 'INFO'
+) -> None:
 
     gpus: Union[List, int] = parse_gpu_ids(gpus)
+    conf_environment = config.environment
+    gpus = get_gpus_from_parser_and_config(gpus, conf_environment)
     assert isinstance(gpus, int), f"Currently, only single-GPU training is supported in this API. Your gpu(s): {gpus}"
 
     os.environ['CUDA_VISIBLE_DEVICES'] = str(gpus)
@@ -38,11 +44,17 @@ def train_with_config(gpus: str, config: TrainerConfig, log_level: Literal['DEBU
     train_common(conf, log_level=log_level)
 
 
-def train_with_yaml(gpus: str, data: Union[Path, str], augmentation: Union[Path, str],
-                    model: Union[Path, str], training: Union[Path, str],
-                    logging: Union[Path, str], environment: Union[Path, str], log_level: str = LOG_LEVEL):
+def train_with_yaml(
+    data: Union[Path, str],
+    augmentation: Union[Path, str],
+    model: Union[Path, str], training: Union[Path, str],
+    logging: Union[Path, str], environment: Union[Path, str],
+    gpus: Optional[str] = None, log_level: str = LOG_LEVEL
+):
 
     gpus: Union[List, int] = parse_gpu_ids(gpus)
+    conf_environment = OmegaConf.load(environment).environment
+    gpus = get_gpus_from_parser_and_config(gpus, conf_environment)
 
     train_with_yaml_impl(
         gpus=gpus,

--- a/train.py
+++ b/train.py
@@ -2,7 +2,7 @@ from netspresso_trainer import train_cli
 
 def train_with_inline_cfg():
     from netspresso_trainer import TrainerConfig, train_with_config, export_config_as_yaml  
-    from netspresso_trainer.cfg import ClassificationResNetModelConfig, ExampleBeansDataset
+    from netspresso_trainer.cfg import ClassificationResNetModelConfig, ClassificationMixNetMediumModelConfig, ExampleBeansDataset
     
     """
     Declare dataset config (Use an example dataset provided from the module)
@@ -12,7 +12,7 @@ def train_with_inline_cfg():
     """
     Declare model config
     """
-    example_model = ClassificationResNetModelConfig()
+    example_model = ClassificationMixNetMediumModelConfig()
     
     # ### If you try to train torch.fx model from PyNetsPresso, use this block instead
     # example_model = ClassificationResNetModelConfig(checkpoint=None)
@@ -33,29 +33,34 @@ def train_with_inline_cfg():
     """
     Update major field values considering the spec of training machine
     """
-    cfg.epochs = 30
+    cfg.epochs = 3
     cfg.logging.csv = True
+    cfg.environment.gpus = "1"
         
-    train_with_config(gpus="0",
-                      config=cfg,
-                      log_level='INFO')
+    train_with_config(
+        # gpus="0",
+        config=cfg,
+        log_level='INFO'
+    )
 
 def train_with_inline_yaml():
     from netspresso_trainer import train_with_yaml
-    train_with_yaml(gpus="0,1",
-                    data="config/data/beans.yaml",
-                    augmentation="config/augmentation/classification.yaml",
-                    model="config/model/resnet/resnet50-classification.yaml",
-                    training="config/training/classification.yaml",
-                    logging="config/logging.yaml",
-                    environment="config/environment.yaml")
+    train_with_yaml(
+        data="config/data/beans.yaml",
+        augmentation="config/augmentation/classification.yaml",
+        model="config/model/resnet/resnet50-classification.yaml",
+        training="config/training/classification.yaml",
+        logging="config/logging.yaml",
+        environment="config/environment.yaml",
+        log_level='DEBUG'
+    )
 
 
 if __name__ == '__main__':
     # train_cli()
 
     # With inline yaml
-    # train_with_inline_yaml()
+    train_with_inline_yaml()
     
     # With inline pythonic config
-    train_with_inline_cfg()
+    # train_with_inline_cfg()

--- a/train.py
+++ b/train.py
@@ -12,7 +12,7 @@ def train_with_inline_cfg():
     """
     Declare model config
     """
-    example_model = ClassificationMixNetMediumModelConfig()
+    example_model = ClassificationResNetModelConfig()
     
     # ### If you try to train torch.fx model from PyNetsPresso, use this block instead
     # example_model = ClassificationResNetModelConfig(checkpoint=None)
@@ -46,13 +46,14 @@ def train_with_inline_cfg():
 def train_with_inline_yaml():
     from netspresso_trainer import train_with_yaml
     train_with_yaml(
+        # gpus="0,1",
         data="config/data/beans.yaml",
         augmentation="config/augmentation/classification.yaml",
         model="config/model/resnet/resnet50-classification.yaml",
         training="config/training/classification.yaml",
         logging="config/logging.yaml",
         environment="config/environment.yaml",
-        log_level='DEBUG'
+        log_level='INFO'
     )
 
 
@@ -60,7 +61,7 @@ if __name__ == '__main__':
     # train_cli()
 
     # With inline yaml
-    train_with_inline_yaml()
+    # train_with_inline_yaml()
     
     # With inline pythonic config
-    # train_with_inline_cfg()
+    train_with_inline_cfg()


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #268 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add gpus option to environment configuration
  - Users can still explicitly designate the gpu ids with argparser.
  - Priority: argparser > training configuration > "0" (=default)


## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 