### PR TITLE
Change optimizer and scheduler configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - Refactoring for detection models by `@illian01` in [PR 260](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/260)
 - Equalize logging format with `PyNetsPresso` by `@deepkyu` in [PR 263](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/263)
-- Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265), [PR 266](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/266), [PR 272](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/272), [PR 273](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/273)
+- Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265), [PR 266](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/266), [PR 272](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/272), [PR 273](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/273), [PR 274](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/274)
 
 # v0.0.10
 

--- a/config/augmentation/classification.yaml
+++ b/config/augmentation/classification.yaml
@@ -4,6 +4,8 @@ augmentation:
     - 
       name: randomresizedcrop
       size: *img_size
+      scale: [0.08, 1.0]
+      ratio: [0.75, 1.33]
       interpolation: bilinear
     - 
       name: randomhorizontalflip
@@ -12,3 +14,5 @@ augmentation:
     -
       name: cutmix
       alpha: 1.0
+      p: 1.0
+      inplace: false

--- a/config/augmentation/detection.yaml
+++ b/config/augmentation/detection.yaml
@@ -5,3 +5,4 @@ augmentation:
       name: resize
       size: *img_size
       interpolation: bilinear
+      max_size: ~

--- a/config/augmentation/segmentation.yaml
+++ b/config/augmentation/segmentation.yaml
@@ -4,6 +4,8 @@ augmentation:
     - 
       name: randomresizedcrop
       size: *img_size
+      scale: [0.08, 1.0]
+      ratio: [0.75, 1.33]
       interpolation: bilinear
     -
       name: randomhorizontalflip

--- a/config/augmentation/template/common.yaml
+++ b/config/augmentation/template/common.yaml
@@ -4,6 +4,8 @@ augmentation:
     - 
       name: randomresizedcrop
       size: ~
+      sclale: ~
+      ratio: ~
       interpolation: bilinear
     -
       name: randomhorizontalflip
@@ -21,7 +23,11 @@ augmentation:
     -
       name: resize
       size: ~
+      interpolation: ~
+      max_size: ~
     -
       name: pad
       padding: ~
+      fill: ~
+      padding_mode: ~
   mix_transforms: ~

--- a/config/training/classification.yaml
+++ b/config/training/classification.yaml
@@ -1,11 +1,5 @@
 training:
   seed: 1
-  sched: cosine
-  min_lr: 1e-6
-  warmup_bias_lr: 1e-5
-  warmup_epochs: 5
-  iters_per_phase: 30
-  sched_power: 1.0
   epochs: 3
   batch_size: 32 
   optimizer:
@@ -13,3 +7,8 @@ training:
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
+  scheduler:
+    name: cosine_no_sgdr
+    warmup_epochs: 5
+    warmup_bias_lr: 1e-5
+    min_lr: 0.

--- a/config/training/classification.yaml
+++ b/config/training/classification.yaml
@@ -1,9 +1,5 @@
 training:
   seed: 1
-  opt: adamw
-  lr: 6e-5
-  momentum: 0.937
-  weight_decay: 0.0005
   sched: cosine
   min_lr: 1e-6
   warmup_bias_lr: 1e-5
@@ -12,3 +8,8 @@ training:
   sched_power: 1.0
   epochs: 3
   batch_size: 32 
+  optimizer:
+    name: adamw
+    lr: 6e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0005

--- a/config/training/detection.yaml
+++ b/config/training/detection.yaml
@@ -1,11 +1,5 @@
 training:
   seed: 1
-  sched: cosine
-  min_lr: 1e-6
-  warmup_bias_lr: 1e-5
-  warmup_epochs: 5
-  iters_per_phase: 30
-  sched_power: 1.0
   epochs: 3
   batch_size: 8 
   optimizer:
@@ -13,3 +7,8 @@ training:
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
+  scheduler:
+    name: cosine_no_sgdr
+    warmup_epochs: 5
+    warmup_bias_lr: 1e-5
+    min_lr: 0.

--- a/config/training/detection.yaml
+++ b/config/training/detection.yaml
@@ -1,9 +1,5 @@
 training:
   seed: 1
-  opt: adamw
-  lr: 6e-5
-  momentum: 0.937
-  weight_decay: 0.0005
   sched: cosine
   min_lr: 1e-6
   warmup_bias_lr: 1e-5
@@ -12,3 +8,8 @@ training:
   sched_power: 1.0
   epochs: 3
   batch_size: 8 
+  optimizer:
+    name: adamw
+    lr: 6e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0005

--- a/config/training/segmentation.yaml
+++ b/config/training/segmentation.yaml
@@ -1,11 +1,5 @@
 training:
   seed: 1
-  sched: cosine
-  min_lr: 1e-6
-  warmup_bias_lr: 1e-5
-  warmup_epochs: 5
-  iters_per_phase: 30
-  sched_power: 1.0
   epochs: 3
   batch_size: 8 
   optimizer:
@@ -13,3 +7,8 @@ training:
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
+  scheduler:
+    name: cosine_no_sgdr
+    warmup_epochs: 5
+    warmup_bias_lr: 1e-5
+    min_lr: 0.

--- a/config/training/segmentation.yaml
+++ b/config/training/segmentation.yaml
@@ -1,9 +1,5 @@
 training:
   seed: 1
-  opt: adamw
-  lr: 6e-5
-  momentum: 0.937
-  weight_decay: 0.0005
   sched: cosine
   min_lr: 1e-6
   warmup_bias_lr: 1e-5
@@ -12,3 +8,8 @@ training:
   sched_power: 1.0
   epochs: 3
   batch_size: 8 
+  optimizer:
+    name: adamw
+    lr: 6e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0005

--- a/config/training/template/common.yaml
+++ b/config/training/template/common.yaml
@@ -1,9 +1,5 @@
 training:
   seed: 1
-  opt: adamw
-  lr: 6e-5
-  momentum: 0.937
-  weight_decay: 0.0005
   sched: cosine
   min_lr: 1e-6
   warmup_bias_lr: 1e-5
@@ -12,3 +8,8 @@ training:
   epochs: 250
   batch_size: 8 
   iters_per_phase: 30
+  optimizer:
+    name: adamw
+    lr: 6e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0005

--- a/config/training/template/common.yaml
+++ b/config/training/template/common.yaml
@@ -1,15 +1,14 @@
 training:
   seed: 1
-  sched: cosine
-  min_lr: 1e-6
-  warmup_bias_lr: 1e-5
-  warmup_epochs: 5
-  sched_power: 1.0
   epochs: 250
   batch_size: 8 
-  iters_per_phase: 30
   optimizer:
     name: adamw
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
+  scheduler:
+    name: cosine_no_sgdr
+    warmup_epochs: 5
+    warmup_bias_lr: 1e-5
+    min_lr: 0.

--- a/src/netspresso_trainer/cfg/augmentation.py
+++ b/src/netspresso_trainer/cfg/augmentation.py
@@ -35,19 +35,22 @@ class ColorJitter(Transform):
 class Pad(Transform):
     name: str = 'pad'
     padding: Union[int, List] = 0
+    fill: Union[int, List] = 0
+    padding_mode: str = 'constant'
 
 
 @dataclass
 class RandomCrop(Transform):
     name: str = 'randomcrop'
     size: int = DEFAULT_IMG_SIZE
-    interpolation: Optional[str] = 'bilinear'
 
 
 @dataclass
 class RandomResizedCrop(Transform):
     name: str = 'randomresizedcrop'
     size: int = DEFAULT_IMG_SIZE
+    scale: List = field(default_factory=lambda: [0.08, 1.0])
+    ratio: List = field(default_factory=lambda: [0.75, 1.33])
     interpolation: Optional[str] = 'bilinear'
 
 
@@ -68,6 +71,14 @@ class Resize(Transform):
     name: str = 'resize'
     size: int = DEFAULT_IMG_SIZE
     interpolation: Optional[str] = 'bilinear'
+    max_size: Optional[int] =  None
+
+
+class TrivialAugmentWide(Transform):
+    name: str = 'trivialaugmentwide'
+    num_magnitude_bins: int = 31
+    interpolation: str = 'bilinear'
+    fill: Optional[Union[int, List]] = None
 
 
 @dataclass
@@ -75,6 +86,7 @@ class RandomMixup(Transform):
     name: str = 'mixup'
     alpha: float = 0.2
     p: float = 1.0
+    inplace: bool = False
 
 
 @dataclass
@@ -82,6 +94,7 @@ class RandomCutmix(Transform):
     name: str = 'cutmix'
     alpha: float = 1.0
     p: float = 1.0
+    inplace: bool = False
 
 
 @dataclass

--- a/src/netspresso_trainer/cfg/training.py
+++ b/src/netspresso_trainer/cfg/training.py
@@ -7,12 +7,6 @@ from omegaconf import MISSING, MissingMandatoryValue
 @dataclass
 class ScheduleConfig:
     seed: int = 1
-    sched: str = "cosine"
-    min_lr: float = 1e-6
-    warmup_bias_lr: float = 1e-5
-    warmup_epochs: int = 5
-    iters_per_phase: int = 30
-    sched_power: float = 1.0
     epochs: int = 3
     batch_size: int = 8
     optimizer: Dict = field(default_factory=lambda: {
@@ -20,6 +14,12 @@ class ScheduleConfig:
         "lr": 6e-5,
         "betas": [0.9, 0.999],
         "weight_decay": 0.0005,
+    })
+    scheduler: Dict = field(default_factory=lambda: {
+        "name": "cosine_no_sgdr",
+        "warmup_epochs": 5,
+        "warmup_bias_lr": 1e-5,
+        "min_lr": 0.,
     })
 
 

--- a/src/netspresso_trainer/cfg/training.py
+++ b/src/netspresso_trainer/cfg/training.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Dict
 
 from omegaconf import MISSING, MissingMandatoryValue
 
@@ -6,10 +7,6 @@ from omegaconf import MISSING, MissingMandatoryValue
 @dataclass
 class ScheduleConfig:
     seed: int = 1
-    opt: str = "adamw"
-    lr: float = 6e-5
-    momentum: float =  0.937
-    weight_decay: float = 0.0005
     sched: str = "cosine"
     min_lr: float = 1e-6
     warmup_bias_lr: float = 1e-5
@@ -18,6 +15,12 @@ class ScheduleConfig:
     sched_power: float = 1.0
     epochs: int = 3
     batch_size: int = 8
+    optimizer: Dict = field(default_factory=lambda: {
+        "name": "adamw",
+        "lr": 6e-5,
+        "betas": [0.9, 0.999],
+        "weight_decay": 0.0005,
+    })
 
 
 @dataclass

--- a/src/netspresso_trainer/dataloaders/augmentation/transforms.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/transforms.py
@@ -49,7 +49,7 @@ def transforms_custom_train(conf_augmentation):
 def transforms_custom_eval(conf_augmentation):
     assert conf_augmentation.img_size > 32
     preprocess = [
-        TC.Resize((conf_augmentation.img_size, conf_augmentation.img_size), interpolation='bilinear'),
+        TC.Resize((conf_augmentation.img_size, conf_augmentation.img_size), interpolation='bilinear', max_size=None),
         TC.ToTensor(),
         TC.Normalize(mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD)
     ]
@@ -76,7 +76,7 @@ def train_transforms_pidnet(conf_augmentation):
 def val_transforms_pidnet(conf_augmentation):
     assert conf_augmentation.img_size > 32
     preprocess = [
-        TC.Resize((conf_augmentation.img_size, conf_augmentation.img_size), interpolation='bilinear'),
+        TC.Resize((conf_augmentation.img_size, conf_augmentation.img_size), interpolation='bilinear', max_size=None),
         TC.ToTensor(),
         TC.Normalize(mean=IMAGENET_DEFAULT_MEAN, std=IMAGENET_DEFAULT_STD)
     ]

--- a/src/netspresso_trainer/optimizers/builder.py
+++ b/src/netspresso_trainer/optimizers/builder.py
@@ -2,6 +2,7 @@
 """
 from typing import Callable, Literal, Optional, Tuple
 
+from omegaconf import DictConfig
 import torch.nn as nn
 
 from .registry import OPTIMIZER_DICT
@@ -9,30 +10,12 @@ from .registry import OPTIMIZER_DICT
 
 def build_optimizer(
     model_or_params,
-    opt: str = 'adamw',
-    lr: Optional[float] = None,
-    wd: float = 0.,
-    momentum: float = 0.9,
+    optimizer_conf: DictConfig,
 ):
-
     parameters = model_or_params.parameters() if isinstance(model_or_params, nn.Module) else model_or_params
 
-    opt_name: Literal['sgd', 'nesterov', 'momentum',
-                      'adam', 'adamw', 'adamax',
-                      'adadelta', 'adagrad', 'rmsprop'] = opt.lower()
+    opt_name: Literal['sgd', 'adam', 'adamw', 'adamax', 'adadelta', 'adagrad', 'rmsprop'] = optimizer_conf.name.lower()
     assert opt_name in OPTIMIZER_DICT
 
-    conf_optim = {'weight_decay': wd, 'lr': lr}
-
-    if opt_name in ['sgd', 'nesterov', 'momentum', 'rmsprop']:
-        conf_optim.update({'momentum': momentum})
-    if opt_name in ['rmsprop']:
-        conf_optim.update({'alpha': 0.9})
-    if opt_name in ['sgd', 'nesterov']:
-        conf_optim.update({'nesterov': True})
-    if opt_name in ['momentum']:
-        conf_optim.update({'nesterov': False})
-
-    optimizer = OPTIMIZER_DICT[opt_name](parameters, **conf_optim)
-
+    optimizer = OPTIMIZER_DICT[opt_name](parameters, optimizer_conf)
     return optimizer

--- a/src/netspresso_trainer/optimizers/builder.py
+++ b/src/netspresso_trainer/optimizers/builder.py
@@ -1,9 +1,7 @@
-""" Inspired from https://github.com/huggingface/pytorch-image-models/blob/main/timm/optim/optim_factory.py
-"""
-from typing import Callable, Literal, Optional, Tuple
+from typing import Literal
 
-from omegaconf import DictConfig
 import torch.nn as nn
+from omegaconf import DictConfig
 
 from .registry import OPTIMIZER_DICT
 

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -1,5 +1,20 @@
 import torch.optim as optim
 
+
+class RMSprop(optim.RMSprop):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        alpha = optimizer_conf.alpha
+        weight_decay = optimizer_conf.weight_decay
+        momentum = optimizer_conf.momentum
+
+        super().__init__(params=params, lr=lr, alpha=alpha, weight_decay=weight_decay, momentum=momentum)
+
+
 class SGD(optim.SGD):
     def __init__(
         self,

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -14,6 +14,19 @@ class Adadelta(optim.Adadelta):
         super().__init__(params=params, lr=lr, rho=rho, weight_decay=weight_decay)
 
 
+class Adagrad(optim.Adagrad):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        lr_decay = optimizer_conf.lr_decay
+        weight_decay = optimizer_conf.weight_decay
+
+        super().__init__(params=params, lr=lr, lr_decay=lr_decay, weight_decay=weight_decay)
+
+
 class Adam(optim.Adam):
     def __init__(
         self,

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -1,0 +1,14 @@
+import torch.optim as optim
+
+class SGD(optim.SGD):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        momentum = optimizer_conf.momentum
+        weight_decay = optimizer_conf.weight_decay
+        nesterov = optimizer_conf.nesterov
+
+        super().__init__(params=params, lr=lr, momentum=momentum, weight_decay=weight_decay, nesterov=nesterov)

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -40,6 +40,19 @@ class Adam(optim.Adam):
         super().__init__(params=params, lr=lr, betas=betas, weight_decay=weight_decay)
 
 
+class Adamax(optim.Adamax):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        betas = optimizer_conf.betas
+        weight_decay = optimizer_conf.weight_decay
+
+        super().__init__(params=params, lr=lr, betas=betas, weight_decay=weight_decay)
+
+
 class AdamW(optim.AdamW):
     def __init__(
         self,

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -1,6 +1,19 @@
 import torch.optim as optim
 
 
+class Adadelta(optim.Adadelta):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        rho = optimizer_conf.rho
+        weight_decay = optimizer_conf.weight_decay
+
+        super().__init__(params=params, lr=lr, rho=rho, weight_decay=weight_decay)
+
+
 class Adam(optim.Adam):
     def __init__(
         self,
@@ -11,7 +24,7 @@ class Adam(optim.Adam):
         betas = optimizer_conf.betas
         weight_decay = optimizer_conf.weight_decay
         
-        super().__init__(params, lr=lr, betas=betas, weight_decay=weight_decay)
+        super().__init__(params=params, lr=lr, betas=betas, weight_decay=weight_decay)
 
 
 class AdamW(optim.AdamW):
@@ -24,7 +37,7 @@ class AdamW(optim.AdamW):
         betas = optimizer_conf.betas
         weight_decay = optimizer_conf.weight_decay
         
-        super().__init__(params, lr=lr, betas=betas, weight_decay=weight_decay)
+        super().__init__(params=params, lr=lr, betas=betas, weight_decay=weight_decay)
 
 
 class RMSprop(optim.RMSprop):

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -14,6 +14,19 @@ class Adam(optim.Adam):
         super().__init__(params, lr=lr, betas=betas, weight_decay=weight_decay)
 
 
+class AdamW(optim.AdamW):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        betas = optimizer_conf.betas
+        weight_decay = optimizer_conf.weight_decay
+        
+        super().__init__(params, lr=lr, betas=betas, weight_decay=weight_decay)
+
+
 class RMSprop(optim.RMSprop):
     def __init__(
         self,

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -1,6 +1,19 @@
 import torch.optim as optim
 
 
+class Adam(optim.Adam):
+    def __init__(
+        self,
+        params,
+        optimizer_conf,
+    ) -> None:
+        lr = optimizer_conf.lr
+        betas = optimizer_conf.betas
+        weight_decay = optimizer_conf.weight_decay
+        
+        super().__init__(params, lr=lr, betas=betas, weight_decay=weight_decay)
+
+
 class RMSprop(optim.RMSprop):
     def __init__(
         self,

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -36,7 +36,7 @@ class Adam(optim.Adam):
         lr = optimizer_conf.lr
         betas = optimizer_conf.betas
         weight_decay = optimizer_conf.weight_decay
-        
+
         super().__init__(params=params, lr=lr, betas=betas, weight_decay=weight_decay)
 
 
@@ -62,7 +62,7 @@ class AdamW(optim.AdamW):
         lr = optimizer_conf.lr
         betas = optimizer_conf.betas
         weight_decay = optimizer_conf.weight_decay
-        
+
         super().__init__(params=params, lr=lr, betas=betas, weight_decay=weight_decay)
 
 

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,6 +4,8 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
+from .custom import SGD
+
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': optim.AdamW,
     'adam': optim.Adam,
@@ -11,5 +13,5 @@ OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adagrad': optim.Adagrad,
     'rmsprop': optim.RMSprop,
     'adamax': optim.Adamax,
-    'sgd': optim.SGD,
+    'sgd': SGD,
 }

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,14 +4,14 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD
+from .custom import SGD, RMSprop
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': optim.AdamW,
     'adam': optim.Adam,
     'adadelta': optim.Adadelta,
     'adagrad': optim.Adagrad,
-    'rmsprop': optim.RMSprop,
+    'rmsprop': RMSprop,
     'adamax': optim.Adamax,
     'sgd': SGD,
 }

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -1,10 +1,8 @@
 from typing import Dict, Type
 
-import torch.nn as nn
-import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD, RMSprop, Adam, AdamW, Adadelta, Adagrad, Adamax
+from .custom import SGD, Adadelta, Adagrad, Adam, Adamax, AdamW, RMSprop
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': AdamW,

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -12,6 +12,4 @@ OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'rmsprop': optim.RMSprop,
     'adamax': optim.Adamax,
     'sgd': optim.SGD,
-    'nesterov': optim.SGD,
-    'momentum': optim.SGD,
 }

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,12 +4,12 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD, RMSprop, Adam, AdamW
+from .custom import SGD, RMSprop, Adam, AdamW, Adadelta
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': AdamW,
     'adam': Adam,
-    'adadelta': optim.Adadelta,
+    'adadelta': Adadelta,
     'adagrad': optim.Adagrad,
     'rmsprop': RMSprop,
     'adamax': optim.Adamax,

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,11 +4,11 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD, RMSprop
+from .custom import SGD, RMSprop, Adam
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': optim.AdamW,
-    'adam': optim.Adam,
+    'adam': Adam,
     'adadelta': optim.Adadelta,
     'adagrad': optim.Adagrad,
     'rmsprop': RMSprop,

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,10 +4,10 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD, RMSprop, Adam
+from .custom import SGD, RMSprop, Adam, AdamW
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
-    'adamw': optim.AdamW,
+    'adamw': AdamW,
     'adam': Adam,
     'adadelta': optim.Adadelta,
     'adagrad': optim.Adagrad,

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD, RMSprop, Adam, AdamW, Adadelta, Adagrad
+from .custom import SGD, RMSprop, Adam, AdamW, Adadelta, Adagrad, Adamax
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': AdamW,
@@ -12,6 +12,6 @@ OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adadelta': Adadelta,
     'adagrad': Adagrad,
     'rmsprop': RMSprop,
-    'adamax': optim.Adamax,
+    'adamax': Adamax,
     'sgd': SGD,
 }

--- a/src/netspresso_trainer/optimizers/registry.py
+++ b/src/netspresso_trainer/optimizers/registry.py
@@ -4,13 +4,13 @@ import torch.nn as nn
 import torch.optim as optim
 from torch.optim.optimizer import Optimizer
 
-from .custom import SGD, RMSprop, Adam, AdamW, Adadelta
+from .custom import SGD, RMSprop, Adam, AdamW, Adadelta, Adagrad
 
 OPTIMIZER_DICT: Dict[str, Type[Optimizer]] = {
     'adamw': AdamW,
     'adam': Adam,
     'adadelta': Adadelta,
-    'adagrad': optim.Adagrad,
+    'adagrad': Adagrad,
     'rmsprop': RMSprop,
     'adamax': optim.Adamax,
     'sgd': SGD,

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -86,10 +86,7 @@ class BasePipeline(ABC):
 
         assert self.model is not None
         self.optimizer = build_optimizer(self.model,
-                                         opt=self.conf.training.opt,
-                                         lr=self.conf.training.lr,
-                                         wd=self.conf.training.weight_decay,
-                                         momentum=self.conf.training.momentum)
+                                         optimizer_conf=self.conf.training.optimizer)
         self.scheduler, _ = build_scheduler(self.optimizer, self.conf.training)
         self.loss_factory = build_losses(self.conf.model, ignore_index=self.ignore_index)
         self.metric_factory = build_metrics(self.task, self.conf.model, ignore_index=self.ignore_index, num_classes=self.num_classes)

--- a/src/netspresso_trainer/schedulers/builder.py
+++ b/src/netspresso_trainer/schedulers/builder.py
@@ -10,7 +10,7 @@ def build_scheduler(optimizer, conf_training):
     num_epochs = conf_training.epochs
 
     # Copy training num_epochs to sub-config scheduler
-    conf_scheduler.total_iters = num_epochs
+    conf_scheduler.total_iters = num_epochs # fix total_iters as num_epochs
 
     assert scheduler_name in SCHEDULER_DICT, f"{scheduler_name} not in scheduler dict!"
     lr_scheduler = SCHEDULER_DICT[scheduler_name](optimizer, conf_scheduler)

--- a/src/netspresso_trainer/schedulers/builder.py
+++ b/src/netspresso_trainer/schedulers/builder.py
@@ -4,15 +4,15 @@ from omegaconf import OmegaConf
 from .registry import SCHEDULER_DICT
 
 
-def build_scheduler(optimizer, conf_training):
-    conf_scheduler = conf_training.scheduler
-    scheduler_name = conf_scheduler.name
-    num_epochs = conf_training.epochs
+def build_scheduler(optimizer, training_conf):
+    scheduler_conf = training_conf.scheduler
+    scheduler_name = scheduler_conf.name
+    num_epochs = training_conf.epochs
 
     # Copy training num_epochs to sub-config scheduler
-    conf_scheduler.total_iters = num_epochs # fix total_iters as num_epochs
+    scheduler_conf.total_iters = num_epochs # fix total_iters as num_epochs
 
     assert scheduler_name in SCHEDULER_DICT, f"{scheduler_name} not in scheduler dict!"
-    lr_scheduler = SCHEDULER_DICT[scheduler_name](optimizer, conf_scheduler)
+    lr_scheduler = SCHEDULER_DICT[scheduler_name](optimizer, scheduler_conf)
 
     return lr_scheduler, num_epochs

--- a/src/netspresso_trainer/schedulers/builder.py
+++ b/src/netspresso_trainer/schedulers/builder.py
@@ -5,18 +5,14 @@ from .registry import SCHEDULER_DICT
 
 
 def build_scheduler(optimizer, conf_training):
-    scheduler_name = conf_training.sched
+    conf_scheduler = conf_training.scheduler
+    scheduler_name = conf_scheduler.name
     num_epochs = conf_training.epochs
-    conf_sched = OmegaConf.create({
-        'min_lr': conf_training.min_lr,
-        'power': conf_training.sched_power,
-        'warmup_bias_lr': conf_training.warmup_bias_lr,
-        'warmup_iters': conf_training.warmup_epochs,
-        'total_iters': num_epochs,
-        'iters_per_phase': conf_training.iters_per_phase,  # TODO: config for StepLR
-    })
+
+    # Copy training num_epochs to sub-config scheduler
+    conf_scheduler.total_iters = num_epochs
 
     assert scheduler_name in SCHEDULER_DICT, f"{scheduler_name} not in scheduler dict!"
-    lr_scheduler = SCHEDULER_DICT[scheduler_name](optimizer, **conf_sched)
+    lr_scheduler = SCHEDULER_DICT[scheduler_name](optimizer, conf_scheduler)
 
     return lr_scheduler, num_epochs

--- a/src/netspresso_trainer/schedulers/cosine_lr.py
+++ b/src/netspresso_trainer/schedulers/cosine_lr.py
@@ -11,20 +11,22 @@ class CosineAnnealingLRWithCustomWarmUp(_LRScheduler):
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
-        warmup_iters (int): The number of steps that the scheduler finishes to warmup the learning rate. Default: 5.
-        total_iters (int): Maximum number of iterations. Originally named as `T_max`. Default: 5.
-        warmup_bias_lr (int): Starting learning rate for warmup period. Default: 0.
-        min_lr (float): Minimum learning rate. Originally named as `eta_min`. Default: 0.
-        last_epoch (int): The index of last epoch. Default: -1.
-        verbose (bool): If ``True``, prints a message to stdout for each update. Default: ``False``.
+        warmup_iters (int): The number of steps that the scheduler finishes to warmup the learning rate.
+        total_iters (int): Maximum number of iterations. Originally named as `T_max`.
+        warmup_bias_lr (int): Starting learning rate for warmup period.
+        min_lr (float): Minimum learning rate. Originally named as `eta_min`.
     """
 
-    def __init__(self, optimizer, warmup_iters=5, total_iters=5, warmup_bias_lr=0, min_lr=0, last_epoch=-1, verbose=False, **kwargs):
-        self.T_max = total_iters
-        self.eta_min = min_lr
-        self.warmup_bias_lr = warmup_bias_lr
-        self.warmup_iters = warmup_iters
-        super().__init__(optimizer, last_epoch, verbose)
+    def __init__(
+        self,
+        optimizer,
+        scheduler_conf,
+    ):
+        self.T_max = scheduler_conf.total_iters
+        self.eta_min = scheduler_conf.min_lr
+        self.warmup_bias_lr = scheduler_conf.warmup_bias_lr
+        self.warmup_iters = scheduler_conf.warmup_epochs
+        super().__init__(optimizer)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:

--- a/src/netspresso_trainer/schedulers/cosine_warm_restart.py
+++ b/src/netspresso_trainer/schedulers/cosine_warm_restart.py
@@ -41,27 +41,34 @@ class CosineAnnealingWarmRestartsWithCustomWarmUp(_LRScheduler):
         https://arxiv.org/abs/1608.03983
     """
 
-    def __init__(self, optimizer, warmup_iters=5, total_iters=5, warmup_bias_lr=0,
-                 iters_per_phase=0, T_mult=1, min_lr=0, last_epoch=-1, verbose=False, **kwargs):
+    def __init__(
+        self,
+        optimizer,
+        scheduler_conf,
+    ):
+        total_iters = scheduler_conf.total_iters
+        iters_per_phase = scheduler_conf.iters_per_phase
+
         if iters_per_phase <= 0 or not isinstance(iters_per_phase, int):
             T_0_maybe = total_iters // 10 if total_iters // 10 != 0 else total_iters
             assert T_0_maybe > 0 and isinstance(T_0_maybe, int)
             logger.info(f"Original T_0 is invalid {iters_per_phase}! Prefer to set T_0 as {T_0_maybe}.")
             iters_per_phase = T_0_maybe
-        if T_mult < 1 or not isinstance(T_mult, int):
-            raise ValueError("Expected integer T_mult >= 1, but got {}".format(T_mult))
+        #if T_mult < 1 or not isinstance(T_mult, int):
+        #    raise ValueError("Expected integer T_mult >= 1, but got {}".format(T_mult))
         if iters_per_phase > total_iters:
             iters_per_phase = total_iters
+
         self.T_0 = iters_per_phase
         self.T_i = iters_per_phase
-        self.T_mult = T_mult
+        self.T_mult = 1 # @illian01: fix as 1 for simplicity
         self.T_i, self.remain_iters = self.get_reassigned_t_i(self.T_0, self.T_i * self.T_mult, total_iters)
         self.total_iters = total_iters
-        self.eta_min = min_lr
-        self.T_cur = last_epoch
-        self.warmup_bias_lr = warmup_bias_lr
-        self.warmup_iters = warmup_iters
-        super().__init__(optimizer, last_epoch, verbose)
+        self.eta_min = scheduler_conf.min_lr
+        self.T_cur = -1 # @illian01: fix as -1 since last_epoch is set to default
+        self.warmup_bias_lr = scheduler_conf.warmup_bias_lr
+        self.warmup_iters = scheduler_conf.warmup_epochs
+        super().__init__(optimizer)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:

--- a/src/netspresso_trainer/schedulers/poly_lr.py
+++ b/src/netspresso_trainer/schedulers/poly_lr.py
@@ -11,20 +11,21 @@ class PolynomialLRWithWarmUp(_LRScheduler):
 
     Args:
         optimizer (Optimizer): Wrapped optimizer.
-        warmup_iters (int): The number of steps that the scheduler finishes to warmup the learning rate. Default: 5.
-        total_iters (int): The number of steps that the scheduler decays the learning rate. Default: 5.
-        power (int): The power of the polynomial. Default: 1.0.
-        verbose (bool): If ``True``, prints a message to stdout for
-            each update. Default: ``False``.
+        warmup_iters (int): The number of steps that the scheduler finishes to warmup the learning rate.
+        total_iters (int): The number of steps that the scheduler decays the learning rate.
+        power (int): The power of the polynomial.
     """
-    def __init__(self, optimizer, warmup_iters=5, total_iters=5, warmup_bias_lr=0, min_lr=0,
-                 power=1.0, last_epoch=-1, verbose=False, **kwargs):
-        self.warmup_iters = warmup_iters
-        self.total_iters = total_iters
-        self.warmup_bias_lr = warmup_bias_lr
-        self.min_lr = min_lr
-        self.power = power if power is not None else 1.0
-        super().__init__(optimizer, last_epoch, verbose)
+    def __init__(
+        self,
+        optimizer,
+        scheduler_conf,
+    ):
+        self.warmup_iters = scheduler_conf.warmup_epochs
+        self.total_iters = scheduler_conf.total_iters
+        self.warmup_bias_lr = scheduler_conf.warmup_bias_lr
+        self.min_lr = scheduler_conf.min_lr
+        self.power = scheduler_conf.power
+        super().__init__(optimizer)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:

--- a/src/netspresso_trainer/schedulers/step_lr.py
+++ b/src/netspresso_trainer/schedulers/step_lr.py
@@ -34,10 +34,15 @@ class StepLR(_LRScheduler):
         >>>     scheduler.step()
     """
 
-    def __init__(self, optimizer, iters_per_phase, gamma=0.1, last_epoch=-1, verbose=False, **kwargs):
-        self.step_size = iters_per_phase
-        self.gamma = gamma
-        super().__init__(optimizer, last_epoch, verbose)
+    def __init__(
+        self,
+        optimizer,
+        scheduler_conf,
+    ):
+        self.step_size = scheduler_conf.iters_per_phase
+        self.gamma = scheduler_conf.gamma
+
+        super().__init__(optimizer)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

Optimizer configuration

- Fields such as `opt`, `lr`, `momentum`, and `weight_decay`, which were previously scattered in the training config, are now consolidated under the `optimizer` field.
    - Under the `optimizer` field, a `name` attribute is set to determine which optimizer to use.
    - Parameters required for each optimizer are defined at the same hierarchical level.
- An optimizer builder is modified to create optimizers based on the configuration from `training.optimizer`.
- Configuration update: yaml and cfg module

Learning rate scheduler configuration

- Fields such as `sched`, `min_lr`, `warmup_bias_lr`, etc., which were previously scattered in the training config, are now consolidated under the `scheduler` field.
    - Under the `scheduler` field, a `name` attribute is set to determine which scheduler to use.
    - Parameters required for each scheduler are defined at the same hierarchical level.
- A scheduler builder is modified to create scheduler based on the configuration from `training.scheduler`.
- Configuration update: yaml and cfg module

Fix error missed at #273

- Fix eval resize parameter bug → add missing `max_size`
- Update configs

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 