### PR TITLE
Add eps param on RMSprop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Equalize logging format with `PyNetsPresso` by `@deepkyu` in [PR 263](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/263)
 - Refactoring for clean docs by `@illian01` in [PR 265](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/265), [PR 266](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/266), [PR 272](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/272), [PR 273](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/273), [PR 274](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/274)
 - Refactoring model building code and move TASK_MODEL_DICT by `@illian01` in [PR 282](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/282)
+- Add eps param on RMSprop by `@illian01` in [PR 285](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/285)
 
 # v0.0.10
 

--- a/src/netspresso_trainer/optimizers/custom.py
+++ b/src/netspresso_trainer/optimizers/custom.py
@@ -76,8 +76,9 @@ class RMSprop(optim.RMSprop):
         alpha = optimizer_conf.alpha
         weight_decay = optimizer_conf.weight_decay
         momentum = optimizer_conf.momentum
+        eps = optimizer_conf.eps
 
-        super().__init__(params=params, lr=lr, alpha=alpha, weight_decay=weight_decay, momentum=momentum)
+        super().__init__(params=params, lr=lr, alpha=alpha, weight_decay=weight_decay, momentum=momentum, eps=eps)
 
 
 class SGD(optim.SGD):


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- We need to adjust `eps` of `RMSprop` to replicate MobileNetV3 of torchvision
  - refer1: [torchvision classification RMSprop eps value](https://github.com/pytorch/vision/blob/f52fd335000fa4d91371e8505749cd7ce9249cf8/references/classification/train.py#L278-L280)
  - refer2: [torchvision MobileNetV3 training script](https://github.com/pytorch/vision/tree/main/references/classification#mobilenetv3-large--small)

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 