### PR TITLE
Update weight path and url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Refactoring model building code and move TASK_MODEL_DICT by `@illian01` in [PR 282](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/282)
 - Add eps param on RMSprop by `@illian01` in [PR 285](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/285)
 - Fix weights loading logic by `@illian01` in [PR 287](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/287), [PR 290](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/290)
+- Change pretrained checkpoint name convention and update weight path and url by `@illian01` in [PR 291](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/291)
 
 # v0.0.10
 

--- a/config/model/efficientformer/efficientformer-l1-classification.yaml
+++ b/config/model/efficientformer/efficientformer-l1-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: efficientformer_l1
-  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.safetensors
+  checkpoint: ./weights/efficientformer/efficientformer_l1_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/efficientformer/efficientformer-l1-detection.yaml
+++ b/config/model/efficientformer/efficientformer-l1-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: efficientformer_l1
-  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.safetensors
+  checkpoint: ./weights/efficientformer/efficientformer_l1_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/efficientformer/efficientformer-l1-segmentation.yaml
+++ b/config/model/efficientformer/efficientformer-l1-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: efficientformer_l1
-  checkpoint: ./weights/efficientformer/efficientformer_l1_1000d.safetensors
+  checkpoint: ./weights/efficientformer/efficientformer_l1_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-l-classification.yaml
+++ b/config/model/mixnet/mixnet-l-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mixnet_l
-  checkpoint: ./weights/mixnet/mixnet_l.safetensors
+  checkpoint: ./weights/mixnet/mixnet_l_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mixnet_l
-  checkpoint: ./weights/mixnet/mixnet_l.safetensors
+  checkpoint: ./weights/mixnet/mixnet_l_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-l-segmentation.yaml
+++ b/config/model/mixnet/mixnet-l-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mixnet_l
-  checkpoint: ./weights/mixnet/mixnet_l.safetensors
+  checkpoint: ./weights/mixnet/mixnet_l_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-m-classification.yaml
+++ b/config/model/mixnet/mixnet-m-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mixnet_m
-  checkpoint: ./weights/mixnet/mixnet_m.safetensors
+  checkpoint: ./weights/mixnet/mixnet_m_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mixnet_m
-  checkpoint: ./weights/mixnet/mixnet_m.safetensors
+  checkpoint: ./weights/mixnet/mixnet_m_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-m-segmentation.yaml
+++ b/config/model/mixnet/mixnet-m-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mixnet_m
-  checkpoint: ./weights/mixnet/mixnet_m.safetensors
+  checkpoint: ./weights/mixnet/mixnet_m_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-s-classification.yaml
+++ b/config/model/mixnet/mixnet-s-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mixnet_s
-  checkpoint: ./weights/mixnet/mixnet_s.safetensors
+  checkpoint: ./weights/mixnet/mixnet_s_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mixnet_s
-  checkpoint: ./weights/mixnet/mixnet_s.safetensors
+  checkpoint: ./weights/mixnet/mixnet_s_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mixnet/mixnet-s-segmentation.yaml
+++ b/config/model/mixnet/mixnet-s-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mixnet_s
-  checkpoint: ./weights/mixnet/mixnet_s.safetensors
+  checkpoint: ./weights/mixnet/mixnet_s_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mobilenet_v3_small
-  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.safetensors
+  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: mobilenet_v3_small
-  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.safetensors
+  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mobilenetv3/mobilenetv3-small-segmentation.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: mobilenet_v3_small
-  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small.safetensors
+  checkpoint: ./weights/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/mobilevit/mobilevit-s-classification.yaml
+++ b/config/model/mobilevit/mobilevit-s-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: mobilevit_s
-  checkpoint: ./weights/mobilevit/mobilevit_s.safetensors
+  checkpoint: ./weights/mobilevit/mobilevit_s_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/resnet/resnet18-classification.yaml
+++ b/config/model/resnet/resnet18-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
-  name: resnet50
-  checkpoint: ./weights/resnet/resnet50_imagenet1k.safetensors
+  name: resnet18
+  checkpoint: ./weights/resnet/resnet18_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
@@ -11,23 +11,23 @@ model:
     backbone:
       name: resnet
       params:
-        block_type: bottleneck
+        block_type: basicblock
         norm_type: batch_norm
       stage_params:
         - 
           channels: 64
-          num_blocks: 3
+          num_blocks: 2
         - 
           channels: 128
-          num_blocks: 4
+          num_blocks: 2
           replace_stride_with_dilation: False
         - 
           channels: 256
-          num_blocks: 6
+          num_blocks: 2
           replace_stride_with_dilation: False
         - 
           channels: 512
-          num_blocks: 3
+          num_blocks: 2
           replace_stride_with_dilation: False
     head:
       name: fc

--- a/config/model/resnet/resnet34-classification.yaml
+++ b/config/model/resnet/resnet34-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
-  name: resnet50
-  checkpoint: ./weights/resnet/resnet50_imagenet1k.safetensors
+  name: resnet34
+  checkpoint: ./weights/resnet/resnet34_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~
@@ -11,7 +11,7 @@ model:
     backbone:
       name: resnet
       params:
-        block_type: bottleneck
+        block_type: basicblock
         norm_type: batch_norm
       stage_params:
         - 

--- a/config/model/segformer/segformer-segmentation.yaml
+++ b/config/model/segformer/segformer-segmentation.yaml
@@ -1,7 +1,7 @@
 model:
   task: segmentation
   name: segformer
-  checkpoint: ./weights/segformer/segformer.safetensors
+  checkpoint: ./weights/segformer/segformer_b0.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/vit/vit-classification.yaml
+++ b/config/model/vit/vit-classification.yaml
@@ -1,7 +1,7 @@
 model:
   task: classification
   name: vit_tiny
-  checkpoint: ./weights/vit/vit_tiny.safetensors
+  checkpoint: ./weights/vit/vit_tiny_imagenet1k.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/config/model/yolox/yolox-detection.yaml
+++ b/config/model/yolox/yolox-detection.yaml
@@ -1,7 +1,7 @@
 model:
   task: detection
   name: yolox_s
-  checkpoint: ./weights/yolox/yolox_s.safetensors
+  checkpoint: ./weights/yolox/yolox_s_coco.safetensors
   load_checkpoint_head: False
   fx_model_checkpoint: ~
   resume_optimizer_checkpoint: ~

--- a/src/netspresso_trainer/cfg/model.py
+++ b/src/netspresso_trainer/cfg/model.py
@@ -474,7 +474,7 @@ class CSPDarkNetSmallArchitectureConfig(ArchitectureConfig):
 class ClassificationEfficientFormerModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "efficientformer_l1"
-    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: EfficientFormerArchitectureConfig(
         head={
             "name": "fc",
@@ -493,7 +493,7 @@ class ClassificationEfficientFormerModelConfig(ModelConfig):
 class SegmentationEfficientFormerModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "efficientformer_l1"
-    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: EfficientFormerArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -512,7 +512,7 @@ class SegmentationEfficientFormerModelConfig(ModelConfig):
 class DetectionEfficientFormerModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "efficientformer_l1"
-    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_1000d.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/efficientformer/efficientformer_l1_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: EfficientFormerArchitectureConfig(
         neck={
             "name": "fpn",
@@ -550,7 +550,7 @@ class DetectionEfficientFormerModelConfig(ModelConfig):
 class ClassificationMobileNetV3ModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mobilenet_v3_small"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileNetV3ArchitectureConfig(
         head={
             "name": "fc",
@@ -569,7 +569,7 @@ class ClassificationMobileNetV3ModelConfig(ModelConfig):
 class SegmentationMobileNetV3ModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mobilenet_v3_small"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileNetV3ArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -588,7 +588,7 @@ class SegmentationMobileNetV3ModelConfig(ModelConfig):
 class DetectionMobileNetV3ModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mobilenet_v3_small"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileNetV3ArchitectureConfig(
         neck={
             "name": "fpn",
@@ -626,7 +626,7 @@ class DetectionMobileNetV3ModelConfig(ModelConfig):
 class ClassificationMobileViTModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mobilevit_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mobilevit/mobilevit_s.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mobilevit/mobilevit_s_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MobileViTArchitectureConfig(
         head={
             "name": "fc",
@@ -656,7 +656,7 @@ class PIDNetModelConfig(ModelConfig):
 class ClassificationResNetModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "resnet50"
-    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ResNetArchitectureConfig(
         head={
             "name": "fc",
@@ -675,7 +675,7 @@ class ClassificationResNetModelConfig(ModelConfig):
 class SegmentationResNetModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "resnet50"
-    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ResNetArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -694,7 +694,7 @@ class SegmentationResNetModelConfig(ModelConfig):
 class DetectionResNetModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "resnet50"
-    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/resnet/resnet50_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ResNetArchitectureConfig(
         neck={
             "name": "fpn",
@@ -732,7 +732,7 @@ class DetectionResNetModelConfig(ModelConfig):
 class SegmentationSegFormerModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "segformer"
-    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/segformer/segformer_b0.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: SegFormerArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -751,7 +751,7 @@ class SegmentationSegFormerModelConfig(ModelConfig):
 class ClassificationViTModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "vit_tiny"
-    checkpoint: Optional[Union[Path, str]] = "./weights/vit/vit_tiny.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/vit/vit_tiny_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: ViTArchitectureConfig(
         head={
             "name": "fc",
@@ -770,7 +770,7 @@ class ClassificationViTModelConfig(ModelConfig):
 class DetectionYoloXModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "yolox_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/yolox/yolox_s.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/yolox/yolox_s_coco.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: CSPDarkNetSmallArchitectureConfig(
         neck={
             "name": "yolopafpn",
@@ -800,7 +800,7 @@ class DetectionYoloXModelConfig(ModelConfig):
 class ClassificationMixNetSmallModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mixnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetSmallArchitectureConfig(
         head={
             "name": "fc",
@@ -819,7 +819,7 @@ class ClassificationMixNetSmallModelConfig(ModelConfig):
 class SegmentationMixNetSmallModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mixnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetSmallArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -838,7 +838,7 @@ class SegmentationMixNetSmallModelConfig(ModelConfig):
 class DetectionMixNetSmallModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mixnet_s"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_s_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetSmallArchitectureConfig(
         neck={
             "name": "fpn",
@@ -876,7 +876,7 @@ class DetectionMixNetSmallModelConfig(ModelConfig):
 class ClassificationMixNetMediumModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mixnet_m"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetMediumArchitectureConfig(
         head={
             "name": "fc",
@@ -895,7 +895,7 @@ class ClassificationMixNetMediumModelConfig(ModelConfig):
 class SegmentationMixNetMediumModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mixnet_m"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetMediumArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -914,7 +914,7 @@ class SegmentationMixNetMediumModelConfig(ModelConfig):
 class DetectionMixNetMediumModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mixnet_m"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_m_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetMediumArchitectureConfig(
         neck={
             "name": "fpn",
@@ -952,7 +952,7 @@ class DetectionMixNetMediumModelConfig(ModelConfig):
 class ClassificationMixNetLargeModelConfig(ModelConfig):
     task: str = "classification"
     name: str = "mixnet_l"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetLargeArchitectureConfig(
         head={
             "name": "fc",
@@ -971,7 +971,7 @@ class ClassificationMixNetLargeModelConfig(ModelConfig):
 class SegmentationMixNetLargeModelConfig(ModelConfig):
     task: str = "segmentation"
     name: str = "mixnet_l"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetLargeArchitectureConfig(
         head={
             "name": "all_mlp_decoder",
@@ -990,7 +990,7 @@ class SegmentationMixNetLargeModelConfig(ModelConfig):
 class DetectionMixNetLargeModelConfig(ModelConfig):
     task: str = "detection"
     name: str = "mixnet_l"
-    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l.safetensors"
+    checkpoint: Optional[Union[Path, str]] = "./weights/mixnet/mixnet_l_imagenet1k.safetensors"
     architecture: ArchitectureConfig = field(default_factory=lambda: MixNetLargeArchitectureConfig(
         neck={
             "name": "fpn",

--- a/src/netspresso_trainer/models/utils.py
+++ b/src/netspresso_trainer/models/utils.py
@@ -14,17 +14,19 @@ FXTensorType = Union[Tensor, Proxy]
 FXTensorListType = Union[List[Tensor], List[Proxy]]
 
 MODEL_CHECKPOINT_URL_DICT = {
-    'resnet50': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/resnet/resnet50.safetensors",
-    'mobilenet_v3_small': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilenetv3/mobilenet_v3_small.safetensors",
-    'segformer': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/segformer/segformer.safetensors",
-    'mobilevit_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilevit/mobilevit_s.safetensors",
-    'vit_tiny': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/vit/vit-tiny.safetensors",
-    'efficientformer_l1': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/efficientformer/efficientformer_l1_1000d.safetensors",
-    'mixnet_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_s.safetensors",
-    'mixnet_m': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_m.safetensors",
-    'mixnet_l': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_l.safetensors",
+    'resnet18_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/resnet/resnet18_imagenet1k.safetensors",
+    'resnet34_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/resnet/resnet34_imagenet1k.safetensors",
+    'resnet50_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/resnet/resnet50_imagenet1k.safetensors",
+    'mobilenet_v3_small_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilenetv3/mobilenet_v3_small_imagenet1k.safetensors",
+    'segformer_b0': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/segformer/segformer_b0.safetensors",
+    'mobilevit_s_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mobilevit/mobilevit_s_imagenet1k.safetensors",
+    'vit_tiny_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/vit/vit_tiny_imagenet1k.safetensors",
+    'efficientformer_l1_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/efficientformer/efficientformer_l1_imagenet1k.safetensors",
+    'mixnet_s_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_s_imagenet1k.safetensors",
+    'mixnet_m_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_m_imagenet1k.safetensors",
+    'mixnet_l_imagenet1k': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/mixnet/mixnet_l_imagenet1k.safetensors",
     'pidnet_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/pidnet/pidnet_s.safetensors",
-    'yolox_s': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/cspdarknet/yolox_s.safetensors",
+    'yolox_s_coco': "https://netspresso-trainer-public.s3.ap-northeast-2.amazonaws.com/checkpoint/yolox/yolox_s_coco.safetensors",
 }
 
 


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Checkpoint name convention has changed
  - e.g. `resnet50.safetensors` -> `resnet50_imagenet1k.safetensors`
- Update model checkpoint urls
- Add `resnet18` and `resnet34` classification configs

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 