### PR TITLE
Fix size param of Resize to receive int or list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ No changes to highlight.
 - Update model caching directory and checkpoint configuration by `@deepkyu` in [PR 299](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/299)
 - Minor docs update by `@illian01` in [PR 300](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/300)
 - Update software development stage by `@illian01` in [PR 301](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/301)
+- Fix size param of Resize to receive int or list by `@illian01` in [PR 310](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/310)
 
 # v0.1.0
 

--- a/docs/components/augmentation/transforms.md
+++ b/docs/components/augmentation/transforms.md
@@ -189,7 +189,7 @@ Naively resize the input image to the given size. This augmentation follows the 
 | Field <img width=200/> | Description |
 |---|---|
 | `name` | (str) Name must be "resize" to use `Resize` transform. |
-| `size` | (int) Desired output size. If size is an int, a square image (`size`, `size`) is made. If provided a list of length 1, it will be interpreted as (`size[0]`, `size[0]`). If a list of length 2 is provided, an image with size (`size[0]`, `size[1]`) is made. |
+| `size` | (int or list) Desired output size. If size is an int, a square image (`size`, `size`) is made. If provided a list of length 1, it will be interpreted as (`size[0]`, `size[0]`). If a list of length 2 is provided, an image with size (`size[0]`, `size[1]`) is made. |
 | `interpolation` | (str) Desired interpolation type. Supporting interpolations are 'nearest', 'bilinear' and 'bicubic'. |
 | `max_size` | (int, optional) The maximum allowed for the longer edge of the resized image: if the longer edge of the image exceeds `max_size` after being resized according to `size`, then the image is resized again so that the longer edge is equal to `max_size`. As a result, `size` might be overruled, i.e the smaller edge may be shorter than `size`. This is only supported if `size` is an int. |
 

--- a/src/netspresso_trainer/dataloaders/augmentation/custom.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom.py
@@ -112,19 +112,11 @@ class Resize(T.Resize):
 
     def __init__(
         self,
-        size: int,
+        size: Union[int, List],
         interpolation: str,
         max_size: Optional[int],
     ):
         interpolation = INVERSE_MODES_MAPPING[interpolation]
-
-        # TODO: There is logic error in forward. If `size` is int, this specify edge for shorter one.
-        # And, this is not match with bbox computing logic.
-        # Thus, automatically transform to sequence format for now,
-        # but this should be specified whether Resize receives sequence or int.
-        if isinstance(size, int):
-            size = [size, size]
-
         # @illian01: antialias paramter always true (always use) for PIL image, and NetsPresso Trainer uses PIL image for augmentation.
         super().__init__(size, interpolation, max_size)
 
@@ -136,7 +128,7 @@ class Resize(T.Resize):
             mask = F.resize(mask, self.size, interpolation=T.InterpolationMode.NEAREST,
                             max_size=self.max_size)
         if bbox is not None:
-            target_w, target_h = (self.size, self.size) if isinstance(self.size, int) else self.size
+            target_w, target_h = image.size # @illian01: Determine ratio according to the actual resized image
             bbox[..., 0:4:2] *= float(target_w / w)
             bbox[..., 1:4:2] *= float(target_h / h)
         return image, mask, bbox


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #309 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Fix size param of Resize to receive int or list

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 