### PR TITLE
Modify PIDNet conv bias, add head_list property on models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ No changes to highlight.
 - Minor docs update by `@illian01` in [PR 300](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/300)
 - Update software development stage by `@illian01` in [PR 301](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/301)
 - Fix size param of Resize to receive int or list by `@illian01` in [PR 310](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/310)
+- Modify PIDNet conv bias, add head_list property on models by `@illian01` in [PR 311](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/311)
 
 # v0.1.0
 

--- a/src/netspresso_trainer/models/base.py
+++ b/src/netspresso_trainer/models/base.py
@@ -34,6 +34,10 @@ class TaskModel(nn.Module):
             m.requires_grad = False
 
     @property
+    def head_list(self):
+        return ('head')
+
+    @property
     def device(self):
         return next(self.parameters()).device
 

--- a/src/netspresso_trainer/models/full/experimental/pidnet.py
+++ b/src/netspresso_trainer/models/full/experimental/pidnet.py
@@ -144,6 +144,10 @@ class PIDNet(nn.Module):
         return layer
 
     @property
+    def head_list(self):
+        return ('seghead_p', 'seghead_d', 'final_layer')
+
+    @property
     def device(self):
         return next(self.parameters()).device
 

--- a/src/netspresso_trainer/models/full/experimental/pidnet.py
+++ b/src/netspresso_trainer/models/full/experimental/pidnet.py
@@ -38,10 +38,10 @@ class PIDNet(nn.Module):
         self.conv1 = nn.Sequential(
             ConvLayer(in_channels=3, out_channels=planes,
                       kernel_size=3, stride=2, padding=1,
-                      norm_type='batch_norm', act_type='relu'),
+                      norm_type='batch_norm', act_type='relu', bias=True),
             ConvLayer(in_channels=planes, out_channels=planes,
                       kernel_size=3, stride=2, padding=1,
-                      norm_type='batch_norm', act_type='relu')
+                      norm_type='batch_norm', act_type='relu',  bias=True)
         )
 
         self.relu = nn.ReLU(inplace=True)

--- a/src/netspresso_trainer/models/full/experimental/pidnet.py
+++ b/src/netspresso_trainer/models/full/experimental/pidnet.py
@@ -41,7 +41,7 @@ class PIDNet(nn.Module):
                       norm_type='batch_norm', act_type='relu', bias=True),
             ConvLayer(in_channels=planes, out_channels=planes,
                       kernel_size=3, stride=2, padding=1,
-                      norm_type='batch_norm', act_type='relu',  bias=True)
+                      norm_type='batch_norm', act_type='relu', bias=True)
         )
 
         self.relu = nn.ReLU(inplace=True)

--- a/src/netspresso_trainer/models/utils.py
+++ b/src/netspresso_trainer/models/utils.py
@@ -151,14 +151,14 @@ def load_from_checkpoint(
     if not load_checkpoint_head:
         logger.info("-"*40)
         logger.info("Head weights are not loaded because model.checkpoint.load_head is set to False")
-        head_keys = [key for key in model_state_dict if key.startswith('head.')]
+        head_keys = [key for key in model_state_dict if key.startswith(model.head_list)]
         for key in head_keys:
             del model_state_dict[key]
 
     missing_keys, unexpected_keys = model.load_state_dict(model_state_dict, strict=False)
 
     if not load_checkpoint_head:
-        missing_keys = [key for key in missing_keys if not key.startswith('head.')]
+        missing_keys = [key for key in missing_keys if not key.startswith(model.head_list)]
 
     if len(missing_keys) != 0:
         logger.warning(f"Missing key(s) in state_dict: {missing_keys}")


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #(issue)

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Modify PIDNet conv1 bias as `True` according to [original repo](https://github.com/XuJiacong/PIDNet/blob/fefa51716bddc13a4321af2c70a074367100645a/models/pidnet.py#L24-L31)
- Add `head_list` property on models to regardlessly handle `TaskModel` or `full-models`.

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 