### PR TITLE
Resize: Match longer side with input size and keep ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features:
 
 - Add activation and dropout layer in FC by `@illian01` in [PR 325](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/325), [PR 327](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/327)
+- Add function to Resize: Match longer side with input size and keep ratio by `@illian01` in [PR 329](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/329)
 
 ## Bug Fixes:
 

--- a/config/augmentation/classification.yaml
+++ b/config/augmentation/classification.yaml
@@ -21,3 +21,4 @@ augmentation:
       size: [*img_size, *img_size]
       interpolation: bilinear
       max_size: ~
+      resize_criteria: ~

--- a/config/augmentation/detection.yaml
+++ b/config/augmentation/detection.yaml
@@ -6,9 +6,11 @@ augmentation:
       size: [*img_size, *img_size]
       interpolation: bilinear
       max_size: ~
+      resize_criteria: ~
   inference:
     - 
       name: resize
       size: [*img_size, *img_size]
       interpolation: bilinear
       max_size: ~
+      resize_criteria: ~

--- a/config/augmentation/segmentation.yaml
+++ b/config/augmentation/segmentation.yaml
@@ -23,3 +23,4 @@ augmentation:
       size: [*img_size, *img_size]
       interpolation: bilinear
       max_size: ~
+      resize_criteria: ~

--- a/docs/components/augmentation/transforms.md
+++ b/docs/components/augmentation/transforms.md
@@ -240,12 +240,13 @@ Naively resize the input image to the given size. This augmentation follows the 
 | Field <img width=200/> | Description |
 |---|---|
 | `name` | (str) Name must be "resize" to use `Resize` transform. |
-| `size` | (int or list) Desired output size. If size is an int, a square image (`size`, `size`) is made. If provided a list of length 1, it will be interpreted as (`size[0]`, `size[0]`). If a list of length 2 is provided, an image with size (`size[0]`, `size[1]`) is made. |
+| `size` | (int or list) Desired output size. If size is a sequence like (h, w), output size will be matched to this. If size is an int, smaller or larger edge of the image will be matched to this number and keep aspect ratio. Determining match to smaller or larger edge is determined by `resize_criteria`. |
 | `interpolation` | (str) Desired interpolation type. Supporting interpolations are 'nearest', 'bilinear' and 'bicubic'. |
 | `max_size` | (int, optional) The maximum allowed for the longer edge of the resized image: if the longer edge of the image exceeds `max_size` after being resized according to `size`, then the image is resized again so that the longer edge is equal to `max_size`. As a result, `size` might be overruled, i.e the smaller edge may be shorter than `size`. This is only supported if `size` is an int. |
+| `resize_criteria` | (str, optional) This field only used when `size` is int. This determines which side (shorter or longer) to match with `size`, and only can have 'short' or 'long' or `None`. i.e, if `resize_criteria` is 'short' and height > width, then image will be rescaled to (size * height / width, size). |
 
 <details>
-  <summary>Resize example</summary>
+  <summary>Resize example - 1</summary>
   
   ```yaml
   augmentation:
@@ -255,6 +256,22 @@ Naively resize the input image to the given size. This augmentation follows the 
         size: [256, 256]
         interpolation: 'bilinear'
         max_size: ~
+        resize_criteria: ~
+  ```
+</details>
+
+<details>
+  <summary>Resize example - 2</summary>
+  
+  ```yaml
+  augmentation:
+    train:
+      - 
+        name: resize
+        size: 256
+        interpolation: 'bilinear'
+        max_size: ~
+        resize_criteria: long
   ```
 </details>
 

--- a/src/netspresso_trainer/cfg/augmentation.py
+++ b/src/netspresso_trainer/cfg/augmentation.py
@@ -70,6 +70,7 @@ class Resize(Transform):
     size: List = field(default_factory=lambda: [DEFAULT_IMG_SIZE, DEFAULT_IMG_SIZE])
     interpolation: Optional[str] = 'bilinear'
     max_size: Optional[int] =  None
+    resize_criteria: Optional[str] = None
 
 
 class TrivialAugmentWide(Transform):


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #328 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add algorithm if `size` is int
  - Match longer side to `size` value when `resize_criteria` is 'long'
- Update configs
- Update docs

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 