### PR TITLE
Update Pad transform to receive target size of image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## Other Changes:
 
 - Refactoring: Move custom transforms to each python module by `@illian01` in [PR 332](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/332)
+- Update Pad transform to receive target size of image by `@illian01` in [PR 334](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/334)
 
 # v0.1.2
 

--- a/docs/components/augmentation/transforms.md
+++ b/docs/components/augmentation/transforms.md
@@ -90,26 +90,37 @@ Currently, NetsPresso Trainer does not support a Gradio demo visualization for M
 
 ### Pad
 
-Pad an image. This augmentation follows the [Pad](https://pytorch.org/vision/0.15/generated/torchvision.transforms.Pad.html#torchvision.transforms.Pad) in torchvision library.
+Pad an image with constant. This augmentation is based on the [Pad](https://pytorch.org/vision/0.15/generated/torchvision.transforms.Pad.html#torchvision.transforms.Pad) in torchvision library.
 
 | Field <img width=200/> | Description |
 |---|---|
 | `name` | (str) Name must be "pad" to use `Pad` transform. |
-| `padding` | (int or list) Padding on each border. If a single int is provided this is used to pad all borders. If list of length 2 is provided this is the padding on left/right and top/bottom respectively. If a list of length 4 is provided this is the padding for the left, top, right and bottom borders respectively. |
-| `fill` | (int or list) This value is only for when the `padding_mode` is "constant". If a single int is provided this is used to fill pixels with constant value. If a list of length 3, it is used to fill R, G, B channels respectively. |
-| `padding_mode` | (str) Type of padding. Should be: constant, edge, reflect, or symmetric. |
+| `size` | (int or list) Padding on each border. If a single int is provided, target size is (`size`, `size`). If a list is provided, it must be length 2, and will produce size of (`size[0]`, `size[1]`) padded image. If each edge of input image is greater or equal than target size, padding will be not processed. |
+| `fill` | (int or list) If a single int is provided this is used to fill pixels with constant value. If a list of length 3, it is used to fill R, G, B channels respectively. |
 
 <details>
-  <summary>Pad example</summary>
+  <summary>Pad example - 1</summary>
   
   ```yaml
   augmentation:
     train:
-      - 
+      -
         name: pad
-        padding: 1
+        size: 512
         fill: 0
-        padding_mode: constant
+  ```
+</details>
+
+<details>
+  <summary>Pad example - 2</summary>
+  
+  ```yaml
+  augmentation:
+    train:
+      -
+        name: pad
+        size: [512, 512]
+        fill: 0
   ```
 </details>
 

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -183,7 +183,12 @@ class RandomVerticalFlip:
 class Pad:
     visualize = True
 
-    def __init__(self, size, fill=0, padding_mode="constant"):
+    def __init__(
+        self,
+        size,
+        fill,
+        padding_mode,
+    ):
         super().__init__()
         if not isinstance(size, (int, Sequence)):
             raise TypeError("Size should be int or sequence. Got {}".format(type(size)))

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -185,9 +185,8 @@ class Pad:
 
     def __init__(
         self,
-        size,
-        fill,
-        padding_mode,
+        size: Union[int, List],
+        fill: Union[int, List],
     ):
         super().__init__()
         if not isinstance(size, (int, Sequence)):
@@ -197,7 +196,7 @@ class Pad:
         self.new_h = size[0] if isinstance(size, Sequence) else size
         self.new_w = size[1] if isinstance(size, Sequence) else size
         self.fill = fill
-        self.padding_mode = padding_mode
+        self.padding_mode = 'constant' # @illian: Fix as constant. I think other options are not gonna used well.
 
     def __call__(self, image, label=None, mask=None, bbox=None, dataset=None):
         if not isinstance(image, (torch.Tensor, Image.Image)):

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -192,8 +192,8 @@ class Pad:
         super().__init__()
         if not isinstance(size, (int, Sequence)):
             raise TypeError("Size should be int or sequence. Got {}".format(type(size)))
-        if isinstance(size, Sequence) and len(size) not in (1, 2):
-            raise ValueError("If size is a sequence, it should have 1 or 2 values")
+        if isinstance(size, Sequence) and len(size) != 2:
+            raise ValueError("If size is a sequence, it should have 2 values")
         self.new_h = size[0] if isinstance(size, Sequence) else size
         self.new_w = size[1] if isinstance(size, Sequence) else size
         self.fill = fill

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -180,7 +180,7 @@ class RandomVerticalFlip:
         return self.__class__.__name__ + "(p={0})".format(self.p)
 
 
-class PadIfNeeded:
+class Pad:
     visualize = True
 
     def __init__(self, size, fill=0, padding_mode="constant"):
@@ -278,7 +278,7 @@ class RandomCrop:
             raise ValueError("If size is a sequence, it should have 1 or 2 values")
         self.size_h = size[0] if isinstance(size, Sequence) else size
         self.size_w = size[1] if isinstance(size, Sequence) else size
-        self.image_pad_if_needed = PadIfNeeded((self.size_h, self.size_w))
+        self.image_pad_if_needed = Pad((self.size_h, self.size_w))
 
     def _crop_bbox(self, bbox, i, j, h, w):
         area_original = (bbox[..., 2] - bbox[..., 0]) * (bbox[..., 3] - bbox[..., 1])

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -92,36 +92,6 @@ class Identity:
         return self.__class__.__name__ + "()"
 
 
-class Pad(T.Pad):
-    visualize = True
-    def __init__(
-        self,
-        padding: Union[int, List],
-        fill: Union[int, List],
-        padding_mode: str,
-    ):
-        super().__init__(padding, fill, padding_mode)
-
-    def forward(self, image, label=None, mask=None, bbox=None, dataset=None):
-        image = F.pad(image, self.padding, self.fill, self.padding_mode)
-        if mask is not None:
-            mask = F.pad(mask, self.padding, fill=255, padding_mode=self.padding_mode)
-        if bbox is not None:
-            target_padding = [self.padding] if not isinstance(self.padding, Sequence) else self.padding
-
-            padding_left, padding_top, _, _ = \
-                target_padding * (4 / len(target_padding))  # supports 1, 2, 4 length
-
-            bbox[..., 0:4:2] += padding_left
-            bbox[..., 1:4:2] += padding_top
-
-        return image, label, mask, bbox
-
-    def __repr__(self):
-        return self.__class__.__name__ + "(padding={0}, fill={1}, padding_mode={2})".format(
-            self.padding, self.fill, self.padding_mode)
-
-
 class Resize(T.Resize):
     visualize = True
 


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #333

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Remove existing `Pad` class and rename `PadIfNeeded` as `Pad`
  - Now, `Pad` class receives target size to pad
- Fix padding type as constant
- Update docs

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 