### PR TITLE
Set dataloader persistent_workers as True

### DIFF
--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -76,9 +76,6 @@ class CenterCrop(T.CenterCrop):
         # TODO: Compute mask, bbox
         return F.center_crop(image, self.size), label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(size={self.size})"
 
@@ -91,9 +88,6 @@ class Identity:
 
     def __call__(self, image, label=None, mask=None, bbox=None, dataset=None):
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         return self.__class__.__name__ + "()"
@@ -136,9 +130,6 @@ class Resize(T.Resize):
             bbox[..., 1:4:2] *= float(target_h / h)
         return image, label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self):
         return self.__class__.__name__ + "(size={0}, interpolation={1}, max_size={2}, antialias={3}, resize_criteria={4})".format(
             self.size, self.interpolation.value, self.max_size, self.antialias, self.resize_criteria)
@@ -163,9 +154,6 @@ class RandomHorizontalFlip:
                 bbox[..., 2::-2] = w - bbox[..., 0:4:2]
         return image, label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self):
         return self.__class__.__name__ + "(p={0})".format(self.p)
 
@@ -188,9 +176,6 @@ class RandomVerticalFlip:
             if bbox is not None:
                 bbox[..., 3::-2] = h - bbox[..., 1:4:2]
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         return self.__class__.__name__ + "(p={0})".format(self.p)
@@ -238,9 +223,6 @@ class Pad:
             bbox[..., 1:4:2] += padding_top
         return image, label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self):
         return self.__class__.__name__ + "(size={0}, fill={1}, padding_mode={2})".format(
             (self.new_h, self.new_w), self.fill, self.padding_mode
@@ -277,9 +259,6 @@ class ColorJitter(T.ColorJitter):
                     image = F.adjust_hue(image, hue_factor)
 
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         return self.__class__.__name__ + \
@@ -335,9 +314,6 @@ class RandomCrop:
             bbox = bbox_candidate
         return image, label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self):
         return self.__class__.__name__ + "(size={0})".format((self.size_h, self.size_w))
 
@@ -392,9 +368,6 @@ class RandomResizedCrop(T.RandomResizedCrop):
             bbox[..., 1:4:2] *= float(target_h / h_cropped)
 
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         interpolate_str = self.interpolation.value
@@ -458,9 +431,6 @@ class RandomErasing(T.RandomErasing):
             # TODO: Object-aware
             return image, label, mask, bbox
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
 
 class TrivialAugmentWide(torch.nn.Module):
@@ -526,9 +496,6 @@ class TrivialAugmentWide(torch.nn.Module):
         # TODO: Compute mask, bbox
         return _apply_op(image, op_name, magnitude, interpolation=self.interpolation, fill=fill), label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self) -> str:
         s = (
             f"{self.__class__.__name__}("
@@ -583,9 +550,6 @@ class AutoAugment(T.AutoAugment):
         # TODO: Compute mask, bbox
         return image, label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
 
 class HSVJitter:
     visualize = True
@@ -615,9 +579,6 @@ class HSVJitter:
         image_hsv = Image.merge('HSV', (h, s, v))
         image = image_hsv.convert('RGB')
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         return self.__class__.__name__ + "(h_mag={0}, s_mag={1}, v_mag={2})".format(
@@ -656,9 +617,6 @@ class RandomResize:
         image, label, mask, bbox = self.resize(image, label, mask, bbox, dataset)
         return image, label, mask, bbox
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self):
         return self.__class__.__name__ + "(base_size={0}, stride={1}, random_range={2})".format(
             self.base_size, self.stride, self.random_range
@@ -675,9 +633,6 @@ class Normalize:
     def __call__(self, image, label=None, mask=None, bbox=None, dataset=None):
         image = F.normalize(image, mean=self.mean, std=self.std)
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         return self.__class__.__name__ + "(mean={0}, std={1})".format(
@@ -696,9 +651,6 @@ class ToTensor(T.ToTensor):
             bbox = torch.as_tensor(np.array(bbox), dtype=torch.float)
 
         return image, label, mask, bbox
-
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
 
     def __repr__(self):
         return self.__class__.__name__ + "()"

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/mosaic.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/mosaic.py
@@ -325,9 +325,6 @@ class MosaicDetection:
 
         return origin_img.astype(np.uint8), origin_labels
 
-    def update_before_epoch(self, cur_epoch, total_epoch):
-        pass
-
     def __repr__(self) -> str:
         return "{}(size={}, mosaic_prob={}, affine_scale={}, degrees={}, translate={}, shear={}, enable_mixup={}, mixup_prob={}, mixup_scale={}, fill={})".format(
             self.__class__.__name__, self.size, self.mosaic_prob, self.affine_scale, self.degrees, self.translate, self.shear, self.enable_mixup, self.mixup_prob, self.mixup_scale, self.fill

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/mosaic.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/mosaic.py
@@ -170,10 +170,8 @@ class MosaicDetection:
         self.fill = fill
         self.mosaic_off_epochs = mosaic_off_epochs
 
-        self.enable_mosaic = True
-
     def __call__(self, image, label=None, mask=None, bbox=None, dataset=None):
-        if self.enable_mosaic and random.random() < self.mosaic_prob:
+        if (self.mosaic_off_epochs <= dataset.end_epoch - dataset.cur_epoch.value) and (random.random() < self.mosaic_prob):
             mosaic_labels = []
             input_dim = self.size
             input_h, input_w = input_dim[0], input_dim[1]
@@ -328,10 +326,7 @@ class MosaicDetection:
         return origin_img.astype(np.uint8), origin_labels
 
     def update_before_epoch(self, cur_epoch, total_epoch):
-        # import START_EPOCH_ZERO_OR_ONE produces circular import error
-        #if total_epoch + START_EPOCH_ZERO_OR_ONE - cur_epoch < self.mosaic_off_epochs:
-        if total_epoch + 1 - cur_epoch <= self.mosaic_off_epochs:
-            self.enable_mosaic = False
+        pass
 
     def __repr__(self) -> str:
         return "{}(size={}, mosaic_prob={}, affine_scale={}, degrees={}, translate={}, shear={}, enable_mixup={}, mixup_prob={}, mixup_scale={}, fill={})".format(

--- a/src/netspresso_trainer/dataloaders/utils/loader.py
+++ b/src/netspresso_trainer/dataloaders/utils/loader.py
@@ -79,7 +79,7 @@ def create_loader(
         fp16=False,
         tf_preprocessing=False,
         use_multi_epochs_loader=False,
-        persistent_workers=False,
+        persistent_workers=True,
         worker_seeding='all',
         world_size=1,
         rank=0,

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -217,14 +217,7 @@ class BasePipeline(ABC):
             logger.error(str(e))
             raise e
 
-    def before_epoch(self, epoch):
-        # Update transforms for every epoch
-        transforms = self.train_dataloader.dataset.transform.transforms
-        for transform in transforms:
-            transform.update_before_epoch(epoch, self.conf.training.epochs)
-
     def train_one_epoch(self, epoch):
-        self.before_epoch(epoch)
         outputs = []
         for _idx, batch in enumerate(tqdm(self.train_dataloader, leave=False)):
             out = self.train_step(batch)

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -2,7 +2,9 @@ import copy
 import json
 import os
 from abc import ABC, abstractmethod
+from ctypes import c_int
 from dataclasses import asdict
+from multiprocessing import Value
 from pathlib import Path
 from statistics import mean
 from typing import Dict, Literal, final
@@ -72,6 +74,11 @@ class BasePipeline(ABC):
                 num_sample_images=NUM_SAMPLES,
                 result_dir=logging_dir,
             )
+
+        # Set current epoch counter and end epoch in dataloader.dataset to use in dataset.transforms 
+        self.cur_epoch = Value(c_int, self.start_epoch)
+        self.train_dataloader.dataset.cur_epoch = self.cur_epoch
+        self.train_dataloader.dataset.end_epoch = self.conf.training.epochs - 1 + self.start_epoch_at_one
 
     @final
     def _is_ready(self):
@@ -167,6 +174,7 @@ class BasePipeline(ABC):
                 self.timer.start_record(name=f'train_epoch_{num_epoch}')
                 self.loss_factory.reset_values()
                 self.metric_factory.reset_values()
+                self.cur_epoch.value = num_epoch
 
                 self.train_one_epoch(epoch=num_epoch)
 

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -75,7 +75,7 @@ class BasePipeline(ABC):
                 result_dir=logging_dir,
             )
 
-        # Set current epoch counter and end epoch in dataloader.dataset to use in dataset.transforms 
+        # Set current epoch counter and end epoch in dataloader.dataset to use in dataset.transforms
         self.cur_epoch = Value(c_int, self.start_epoch)
         self.train_dataloader.dataset.cur_epoch = self.cur_epoch
         self.train_dataloader.dataset.end_epoch = self.conf.training.epochs - 1 + self.start_epoch_at_one


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #343 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add multiprocessing.Value to training pipeline and dataloader.dataset which indicates current epoch.
- Update some transform functionality according to the multiprocessing.Value.

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 