### PR TITLE
Gather predicted results before compute metric 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## Bug Fixes:
 
 - Fix output_root_dir from fixed string to config value by `@illian01` in [PR 323](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/323)
-- Gather predicted results before compute metric by `@illian01` in [PR 346](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/346)
+- Gather predicted results before compute metric and fix additional distributed evaluation inaccurate error by `@illian01` in [PR 346](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/346)
 
 ## Breaking Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Bug Fixes:
 
 - Fix output_root_dir from fixed string to config value by `@illian01` in [PR 323](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/323)
+- Gather predicted results before compute metric by `@illian01` in [PR 346](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/346)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/dataloaders/classification/dataset.py
+++ b/src/netspresso_trainer/dataloaders/classification/dataset.py
@@ -70,33 +70,39 @@ def is_file_dict(image_dir: Union[Path, str], file_or_dir_to_idx):
 
 
 def classification_mix_collate_fn(original_batch, mix_transforms):
+    indices = []
     images = []
     target = []
     for data_sample in original_batch:
-        images.append(data_sample[0])
-        target.append(data_sample[1])
+        indices.append(data_sample[0])
+        images.append(data_sample[1])
+        target.append(data_sample[2])
 
+    indices = torch.tensor(indices, dtype=torch.long)
     images = torch.stack(images, dim=0)
     target = torch.tensor(target, dtype=torch.long)
 
     images, target = mix_transforms(images, target)
 
-    outputs = (images, target)
+    outputs = (indices, images, target)
     return outputs
 
 
 def classification_onehot_collate_fn(original_batch, num_classes):
+    indices = []
     images = []
     target = []
     for data_sample in original_batch:
-        images.append(data_sample[0])
-        target.append(data_sample[1])
+        indices.append(data_sample[0])
+        images.append(data_sample[1])
+        target.append(data_sample[2])
 
+    indices = torch.tensor(indices, dtype=torch.long)
     images = torch.stack(images, dim=0)
     target = torch.tensor(target, dtype=torch.long)
     target = F.one_hot(target, num_classes=num_classes).to(dtype=images.dtype)
 
-    outputs = (images, target)
+    outputs = (indices, images, target)
     return outputs
 
 

--- a/src/netspresso_trainer/dataloaders/classification/huggingface.py
+++ b/src/netspresso_trainer/dataloaders/classification/huggingface.py
@@ -60,4 +60,4 @@ class ClassificationHFDataset(BaseHFDataset):
             out = self.transform(img)
         if target is None:
             target = -1
-        return out['image'], target
+        return index, out['image'], target

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -24,4 +24,4 @@ class ClassificationCustomDataset(BaseCustomDataset):
 
         if target is None:
             target = -1  # To be ignored at cross-entropy loss
-        return out['image'], target
+        return index, out['image'], target

--- a/src/netspresso_trainer/dataloaders/detection/dataset.py
+++ b/src/netspresso_trainer/dataloaders/detection/dataset.py
@@ -20,11 +20,14 @@ def load_custom_class_map(id_mapping: List[str]):
     return idx_to_class
 
 def detection_collate_fn(original_batch):
+    indices = []
     pixel_values = []
     bbox = []
     label = []
     org_shape = []
     for data_sample in original_batch:
+        if 'indices' in data_sample:
+            indices.append(data_sample['indices'])
         if 'pixel_values' in data_sample:
             pixel_values.append(data_sample['pixel_values'])
         if 'bbox' in data_sample:
@@ -34,6 +37,9 @@ def detection_collate_fn(original_batch):
         if 'org_shape' in data_sample:
             org_shape.append(data_sample['org_shape'])
     outputs = {}
+    if len(indices) != 0:
+        indices = torch.tensor(indices, dtype=torch.long)
+        outputs.update({'indices': indices})
     if len(pixel_values) != 0:
         pixel_values = torch.stack(pixel_values, dim=0)
         outputs.update({'pixel_values': pixel_values})

--- a/src/netspresso_trainer/dataloaders/detection/local.py
+++ b/src/netspresso_trainer/dataloaders/detection/local.py
@@ -81,7 +81,7 @@ class DetectionCustomDataset(BaseCustomDataset):
         outputs.update({'pixel_values': out['image'], 'bbox': out['bbox'],
                         'label': out['label']})
 
-
+        outputs.update({'indices': index})
         if self._split in ['train', 'training']:
             return outputs
 

--- a/src/netspresso_trainer/dataloaders/segmentation/huggingface.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/huggingface.py
@@ -89,6 +89,7 @@ class SegmentationHFDataset(BaseHFDataset):
             out = self.transform(image=img, mask=mask)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'name': img_name})
 
+        outputs.update({'indices': index})
         if self._split in ['train', 'training']:
             return outputs
 

--- a/src/netspresso_trainer/dataloaders/segmentation/local.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/local.py
@@ -59,6 +59,7 @@ class SegmentationCustomDataset(BaseCustomDataset):
             out = self.transform(image=img, mask=mask)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'name': img_path.name})
 
+        outputs.update({'indices': index})
         if self._split in ['train', 'training']:
             return outputs
 

--- a/src/netspresso_trainer/dataloaders/utils/sampler.py
+++ b/src/netspresso_trainer/dataloaders/utils/sampler.py
@@ -1,0 +1,119 @@
+"""
+Based on the publicly available DeepDeblur-PyTorch repository.
+https://github.com/SeungjunNah/DeepDeblur-PyTorch/blob/master/src/data/sampler.py
+"""
+import math
+import torch
+from torch.utils.data import Sampler
+import torch.distributed as dist
+
+
+class DistributedEvalSampler(Sampler):
+    r"""
+    DistributedEvalSampler is different from DistributedSampler.
+    It does NOT add extra samples to make it evenly divisible.
+    DistributedEvalSampler should NOT be used for training. The distributed processes could hang forever.
+    See this issue for details: https://github.com/pytorch/pytorch/issues/22584
+    shuffle is disabled by default
+
+    DistributedEvalSampler is for evaluation purpose where synchronization does not happen every epoch.
+    Synchronization should be done outside the dataloader loop.
+
+    Sampler that restricts data loading to a subset of the dataset.
+
+    It is especially useful in conjunction with
+    :class:`torch.nn.parallel.DistributedDataParallel`. In such a case, each
+    process can pass a :class`~torch.utils.data.DistributedSampler` instance as a
+    :class:`~torch.utils.data.DataLoader` sampler, and load a subset of the
+    original dataset that is exclusive to it.
+
+    .. note::
+        Dataset is assumed to be of constant size.
+
+    Arguments:
+        dataset: Dataset used for sampling.
+        num_replicas (int, optional): Number of processes participating in
+            distributed training. By default, :attr:`rank` is retrieved from the
+            current distributed group.
+        rank (int, optional): Rank of the current process within :attr:`num_replicas`.
+            By default, :attr:`rank` is retrieved from the current distributed
+            group.
+        shuffle (bool, optional): If ``True`` (default), sampler will shuffle the
+            indices.
+        seed (int, optional): random seed used to shuffle the sampler if
+            :attr:`shuffle=True`. This number should be identical across all
+            processes in the distributed group. Default: ``0``.
+
+    .. warning::
+        In distributed mode, calling the :meth`set_epoch(epoch) <set_epoch>` method at
+        the beginning of each epoch **before** creating the :class:`DataLoader` iterator
+        is necessary to make shuffling work properly across multiple epochs. Otherwise,
+        the same ordering will be always used.
+
+    Example::
+
+        >>> sampler = DistributedSampler(dataset) if is_distributed else None
+        >>> loader = DataLoader(dataset, shuffle=(sampler is None),
+        ...                     sampler=sampler)
+        >>> for epoch in range(start_epoch, n_epochs):
+        ...     if is_distributed:
+        ...         sampler.set_epoch(epoch)
+        ...     train(loader)
+    """
+
+    def __init__(self, dataset, num_replicas=None, rank=None, shuffle=False, seed=0):
+        if num_replicas is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            num_replicas = dist.get_world_size()
+        if rank is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            rank = dist.get_rank()
+        self.dataset = dataset
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.epoch = 0
+        # self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.num_replicas))
+        # self.total_size = self.num_samples * self.num_replicas
+        self.total_size = len(self.dataset)         # true value without extra samples
+        indices = list(range(self.total_size))
+        indices = indices[self.rank:self.total_size:self.num_replicas]
+        self.num_samples = len(indices)             # true value without extra samples
+
+        self.shuffle = shuffle
+        self.seed = seed
+
+    def __iter__(self):
+        if self.shuffle:
+            # deterministically shuffle based on epoch and seed
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(len(self.dataset), generator=g).tolist()
+        else:
+            indices = list(range(len(self.dataset)))
+
+
+        # # add extra samples to make it evenly divisible
+        # indices += indices[:(self.total_size - len(indices))]
+        # assert len(indices) == self.total_size
+
+        # subsample
+        indices = indices[self.rank:self.total_size:self.num_replicas]
+        assert len(indices) == self.num_samples
+
+        return iter(indices)
+
+    def __len__(self):
+        return self.num_samples
+
+    def set_epoch(self, epoch):
+        r"""
+        Sets the epoch for this sampler. When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+
+        Arguments:
+            epoch (int): _epoch number.
+        """
+        self.epoch = epoch

--- a/src/netspresso_trainer/dataloaders/utils/sampler.py
+++ b/src/netspresso_trainer/dataloaders/utils/sampler.py
@@ -77,10 +77,8 @@ class DistributedEvalSampler(Sampler):
         self.epoch = 0
         # self.num_samples = int(math.ceil(len(self.dataset) * 1.0 / self.num_replicas))
         # self.total_size = self.num_samples * self.num_replicas
-        self.total_size = len(self.dataset)         # true value without extra samples
-        indices = list(range(self.total_size))
-        indices = indices[self.rank:self.total_size:self.num_replicas]
-        self.num_samples = len(indices)             # true value without extra samples
+        self.num_samples = math.ceil(len(self.dataset) / self.num_replicas)             # true value without extra samples
+        self.total_size = self.num_samples * self.num_replicas
 
         self.shuffle = shuffle
         self.seed = seed
@@ -98,6 +96,7 @@ class DistributedEvalSampler(Sampler):
         # # add extra samples to make it evenly divisible
         # indices += indices[:(self.total_size - len(indices))]
         # assert len(indices) == self.total_size
+        indices += [-1 for _ in range(self.total_size - len(indices))]
 
         # subsample
         indices = indices[self.rank:self.total_size:self.num_replicas]

--- a/src/netspresso_trainer/dataloaders/utils/sampler.py
+++ b/src/netspresso_trainer/dataloaders/utils/sampler.py
@@ -3,9 +3,10 @@ Based on the publicly available DeepDeblur-PyTorch repository.
 https://github.com/SeungjunNah/DeepDeblur-PyTorch/blob/master/src/data/sampler.py
 """
 import math
+
 import torch
-from torch.utils.data import Sampler
 import torch.distributed as dist
+from torch.utils.data import Sampler
 
 
 class DistributedEvalSampler(Sampler):

--- a/src/netspresso_trainer/metrics/builder.py
+++ b/src/netspresso_trainer/metrics/builder.py
@@ -33,7 +33,8 @@ class MetricFactory:
         self.__call__(pred=pred, target=target, phase=phase, **kwargs)
 
     def __call__(self, pred: torch.Tensor, target: torch.Tensor, phase: str, **kwargs: Any) -> None:
-
+        if pred.size(0) == 0: # Removed dummy batch has 0 len
+            return
         metric_result_dict = self.metric_fn.calibrate(pred, target)
         phase = phase.lower()
         assert phase in PHASE_LIST, f"{phase} is not defined at our phase list ({PHASE_LIST})"

--- a/src/netspresso_trainer/metrics/builder.py
+++ b/src/netspresso_trainer/metrics/builder.py
@@ -33,7 +33,7 @@ class MetricFactory:
         self.__call__(pred=pred, target=target, phase=phase, **kwargs)
 
     def __call__(self, pred: torch.Tensor, target: torch.Tensor, phase: str, **kwargs: Any) -> None:
-        if pred.size(0) == 0: # Removed dummy batch has 0 len
+        if len(pred) == 0: # Removed dummy batch has 0 len
             return
         metric_result_dict = self.metric_fn.calibrate(pred, target)
         phase = phase.lower()

--- a/src/netspresso_trainer/pipelines/detection.py
+++ b/src/netspresso_trainer/pipelines/detection.py
@@ -47,7 +47,7 @@ class DetectionPipeline(BasePipeline):
 
     def valid_step(self, batch):
         self.model.eval()
-        images, labels, bboxes = batch['pixel_values'], batch['label'], batch['bbox']
+        indices, images, labels, bboxes = batch['indices'], batch['pixel_values'], batch['label'], batch['bbox']
         images = images.to(self.devices)
         targets = [{"boxes": box.to(self.devices), "labels": label.to(self.devices)}
                    for box, label in zip(bboxes, labels)]
@@ -64,6 +64,19 @@ class DetectionPipeline(BasePipeline):
         pred = self.postprocessor(out, original_shape=images[0].shape)
 
         if self.conf.distributed:
+            # Remove dummy samples, they only come in distributed environment
+            images = images[indices != -1]
+            filtered_bboxes = []
+            filtered_labels = []
+            filtered_pred = []
+            for idx, bool_idx in enumerate(indices != -1):
+                if bool_idx:
+                    filtered_bboxes.append(bboxes[idx])
+                    filtered_labels.append(labels[idx])
+                    filtered_pred.append(pred[idx])
+            bboxes = filtered_bboxes
+            labels = filtered_labels
+            pred = filtered_pred
             torch.distributed.barrier()
 
         logs = {
@@ -76,12 +89,21 @@ class DetectionPipeline(BasePipeline):
 
     def test_step(self, batch):
         self.model.eval()
-        images = batch['pixel_values']
+        indices, images = batch['indices'], batch['pixel_values']
         images = images.to(self.devices)
 
         out = self.model(images.unsqueeze(0))
 
         pred = self.postprocessor(out, original_shape=images[0].shape)
+
+        if self.conf.distributed:
+            # Remove dummy samples, they only come in distributed environment
+            filtered_pred = []
+            for idx, bool_idx in enumerate(indices != -1):
+                if bool_idx:
+                    filtered_pred.append(pred[idx])
+            pred = filtered_pred
+            torch.distributed.barrier()
 
         results = pred
         return results
@@ -100,6 +122,9 @@ class DetectionPipeline(BasePipeline):
             pred = []
             targets = []
             for output_batch in outputs:
+                if len(output_batch['target']) == 0:
+                    continue
+
                 for detection, class_idx in output_batch['target']:
                     target_on_image = {}
                     target_on_image['boxes'] = detection


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #342 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Gather predicted outputs to compute detection metric.
- Add `DistributedEvalSampler` for validation dataloader.
  - Padding -1 index samples to make divisible by `world_size`
  - Remove dummy samples before compute metrics
  - To remove dummy samples, `__getitem__` method of datasets return index
- Modify `drop_last` value.

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 