### PR TITLE
Add dataset caching feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add model EMA (Exponential Moving Average) by `@illian01` in [PR 348](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/348)
 - Add entry point for evaluation and inference by `@illian01` in [PR 374](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/374), [PR 379](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/379), [PR 381](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/381), [PR 383](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/383)
 - Add classification visulizer by `@illian01` in [PR 384](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/384)
+- Add dataset caching feature by `@illian01` in [Pr 391](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/391)
 
 ## Bug Fixes:
 

--- a/src/netspresso_trainer/dataloaders/base.py
+++ b/src/netspresso_trainer/dataloaders/base.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.utils.data as data
+import PIL.Image as Image
+from tqdm import tqdm
 
 
 class BaseCustomDataset(data.Dataset):
@@ -52,6 +54,9 @@ class BaseCustomDataset(data.Dataset):
     def with_label(self):
         return self._with_label
 
+    def cache_dataset(self, sampler):
+        for i in tqdm(sampler):
+            self.samples[i]['image'] = Image.open(str(self.samples[i]['image'])).convert('RGB')
 
 class BaseHFDataset(data.Dataset):
 

--- a/src/netspresso_trainer/dataloaders/base.py
+++ b/src/netspresso_trainer/dataloaders/base.py
@@ -6,8 +6,6 @@ from pathlib import Path
 import numpy as np
 import torch
 import torch.utils.data as data
-import PIL.Image as Image
-from tqdm import tqdm
 
 
 class BaseCustomDataset(data.Dataset):
@@ -33,6 +31,10 @@ class BaseCustomDataset(data.Dataset):
     def __getitem__(self, index):
         pass
 
+    @abstractmethod
+    def cache_dataset(self, sampler):
+        pass
+
     def __len__(self):
         return len(self.samples)
 
@@ -55,11 +57,6 @@ class BaseCustomDataset(data.Dataset):
     @property
     def with_label(self):
         return self._with_label
-
-    def cache_dataset(self, sampler):
-        for i in tqdm(sampler):
-            self.samples[i]['image'] = Image.open(str(self.samples[i]['image'])).convert('RGB')
-        self.cache = True
 
 class BaseHFDataset(data.Dataset):
 

--- a/src/netspresso_trainer/dataloaders/base.py
+++ b/src/netspresso_trainer/dataloaders/base.py
@@ -27,6 +27,8 @@ class BaseCustomDataset(data.Dataset):
         self._split = split
         self._with_label = with_label
 
+        self.cache = False
+
     @abstractmethod
     def __getitem__(self, index):
         pass
@@ -57,6 +59,7 @@ class BaseCustomDataset(data.Dataset):
     def cache_dataset(self, sampler):
         for i in tqdm(sampler):
             self.samples[i]['image'] = Image.open(str(self.samples[i]['image'])).convert('RGB')
+        self.cache = True
 
 class BaseHFDataset(data.Dataset):
 

--- a/src/netspresso_trainer/dataloaders/base.py
+++ b/src/netspresso_trainer/dataloaders/base.py
@@ -32,7 +32,7 @@ class BaseCustomDataset(data.Dataset):
         pass
 
     @abstractmethod
-    def cache_dataset(self, sampler):
+    def cache_dataset(self, sampler, distributed):
         pass
 
     def __len__(self):

--- a/src/netspresso_trainer/dataloaders/builder.py
+++ b/src/netspresso_trainer/dataloaders/builder.py
@@ -97,6 +97,7 @@ def build_dataset(conf_data, conf_augmentation, task: str, model_name: str, dist
 
 
 def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=False):
+    is_training = True if phase == 'train' else False
 
     if task == 'classification':
         # TODO: ``phase`` should be removed later.
@@ -122,7 +123,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             logger,
             input_size=conf.augmentation.img_size,
             batch_size=conf.environment.batch_size,
-            is_training=True,
+            is_training=is_training,
             num_workers=conf.environment.num_workers if not profile else 1,
             distributed=conf.distributed,
             collate_fn=collate_fn,
@@ -144,7 +145,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             conf.data.name,
             logger,
             batch_size=batch_size,
-            is_training=True,
+            is_training=is_training,
             num_workers=conf.environment.num_workers if not profile else 1,
             distributed=conf.distributed,
             collate_fn=collate_fn,
@@ -166,7 +167,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             conf.data.name,
             logger,
             batch_size=batch_size,
-            is_training=True,
+            is_training=is_training,
             num_workers=conf.environment.num_workers if not profile else 1,
             distributed=conf.distributed,
             collate_fn=collate_fn,
@@ -183,7 +184,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             conf.data.name,
             logger,
             batch_size=conf.environment.batch_size,
-            is_training=True,
+            is_training=is_training,
             num_workers=conf.environment.num_workers if not profile else 1,
             distributed=conf.distributed,
             collate_fn=collate_fn,

--- a/src/netspresso_trainer/dataloaders/builder.py
+++ b/src/netspresso_trainer/dataloaders/builder.py
@@ -97,7 +97,7 @@ def build_dataset(conf_data, conf_augmentation, task: str, model_name: str, dist
 
 
 def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=False):
-    is_training = True if phase == 'train' else False
+    is_training = phase == 'train'
 
     #TODO: Temporarily set ``cache_data`` as optional since this is experimental
     cache_data = conf.environment.cache_data if hasattr(conf.environment, 'cache_data') else False

--- a/src/netspresso_trainer/dataloaders/builder.py
+++ b/src/netspresso_trainer/dataloaders/builder.py
@@ -99,6 +99,9 @@ def build_dataset(conf_data, conf_augmentation, task: str, model_name: str, dist
 def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=False):
     is_training = True if phase == 'train' else False
 
+    #TODO: Temporarily set ``cache_data`` as optional since this is experimental
+    cache_data = conf.environment.cache_data if hasattr(conf.environment, 'cache_data') else False
+
     if task == 'classification':
         # TODO: ``phase`` should be removed later.
         transforms = getattr(conf.augmentation, phase, None)
@@ -130,6 +133,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             pin_memory=False,
             world_size=conf.world_size,
             rank=conf.rank,
+            cache_data=cache_data,
             kwargs=None
         )
     elif task == 'segmentation':
@@ -152,6 +156,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             pin_memory=False,
             world_size=conf.world_size,
             rank=conf.rank,
+            cache_data=cache_data,
             kwargs=None
         )
     elif task == 'detection':
@@ -174,6 +179,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             pin_memory=False,
             world_size=conf.world_size,
             rank=conf.rank,
+            cache_data=cache_data,
             kwargs=None
         )
     elif task == 'pose_estimation':
@@ -191,6 +197,7 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             pin_memory=False,
             world_size=conf.world_size,
             rank=conf.rank,
+            cache_data=cache_data,
             kwargs=None
         )
     else:

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -1,12 +1,12 @@
-from functools import partial
 import os
-
-import PIL.Image as Image
-from loguru import logger
+from functools import partial
 from multiprocessing.pool import ThreadPool
 
-from ..base import BaseCustomDataset
+import PIL.Image as Image
 import torch.distributed as dist
+from loguru import logger
+
+from ..base import BaseCustomDataset
 
 
 class ClassificationCustomDataset(BaseCustomDataset):

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -14,10 +14,15 @@ class ClassificationCustomDataset(BaseCustomDataset):
             split, samples, transform, with_label, **kwargs
         )
 
+    def cache_dataset(self, sampler):
+        for i in sampler:
+            self.samples[i]['image'] = Image.open(str(self.samples[i]['image'])).convert('RGB')
+            self.cache = True
+
     def __getitem__(self, index):
         img = self.samples[index]['image']
         target = self.samples[index]['label'] if 'label' in self.samples[index] else None
-        img = Image.open(img).convert('RGB')
+        #img = Image.open(img).convert('RGB')
 
         if self.transform is not None:
             out = self.transform(img)

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -1,8 +1,10 @@
 import os
 
 import PIL.Image as Image
+from loguru import logger
 
 from ..base import BaseCustomDataset
+import torch.distributed as dist
 
 
 class ClassificationCustomDataset(BaseCustomDataset):
@@ -14,7 +16,9 @@ class ClassificationCustomDataset(BaseCustomDataset):
             split, samples, transform, with_label, **kwargs
         )
 
-    def cache_dataset(self, sampler):
+    def cache_dataset(self, sampler, distributed):
+        if (not distributed) or (distributed and dist.get_rank() == 0):
+            logger.info(f'Caching | Loading samples of {self.mode} to memory... This can take minutes.')
         for i in sampler:
             self.samples[i]['image'] = Image.open(str(self.samples[i]['image'])).convert('RGB')
             self.cache = True

--- a/src/netspresso_trainer/dataloaders/classification/local.py
+++ b/src/netspresso_trainer/dataloaders/classification/local.py
@@ -21,8 +21,9 @@ class ClassificationCustomDataset(BaseCustomDataset):
 
     def __getitem__(self, index):
         img = self.samples[index]['image']
-        target = self.samples[index]['label'] if 'label' in self.samples[index] else None
-        #img = Image.open(img).convert('RGB')
+        target = self.samples[index]['label']
+        if not self.cache:
+            img = Image.open(img).convert('RGB')
 
         if self.transform is not None:
             out = self.transform(img)

--- a/src/netspresso_trainer/dataloaders/detection/local.py
+++ b/src/netspresso_trainer/dataloaders/detection/local.py
@@ -1,10 +1,14 @@
+from functools import partial
 import os
 from pathlib import Path
 from typing import List
 
 import numpy as np
 import PIL.Image as Image
+from loguru import logger
+from multiprocessing.pool import ThreadPool
 import torch
+import torch.distributed as dist
 from omegaconf import OmegaConf
 
 from ..base import BaseCustomDataset
@@ -54,21 +58,47 @@ class DetectionCustomDataset(BaseCustomDataset):
         converted[..., 3] = h * (original[..., 1] + original[..., 3] / 2) + padh
         return converted
 
+    def cache_dataset(self, sampler, distributed):
+        if (not distributed) or (distributed and dist.get_rank() == 0):
+            logger.info(f'Caching | Loading samples of {self.mode} to memory... This can take minutes.')
+
+        def _load(i, samples):
+            image = Image.open(Path(samples[i]['image'])).convert('RGB')
+            label = self.samples[i]['label']
+            if label is not None:
+                label = get_label(Path(label))
+            return i, image, label
+
+        num_threads = 8 # TODO: Compute appropriate num_threads
+        load_imgs = ThreadPool(num_threads).imap(
+            partial(_load, samples=self.samples),
+            sampler
+        )
+        for i, image, label in load_imgs:
+            self.samples[i]['image'] = image
+            self.samples[i]['label'] = label
+
+        self.cache = True
+
     def __getitem__(self, index):
-        img_path = Path(self.samples[index]['image'])
-        ann_path = Path(self.samples[index]['label']) if self.samples[index]['label'] is not None else None
-        img = Image.open(str(img_path)).convert('RGB')
+        if self.cache:
+            img = self.samples[index]['image']
+            ann = self.samples[index]['label']
+        else:
+            img = Image.open(self.samples[index]['image']).convert('RGB')        
+            ann_path = Path(self.samples[index]['label']) if self.samples[index]['label'] is not None else None
+            ann = get_label(Path(ann_path)) if ann_path is not None else None
 
         w, h = img.size
 
         outputs = {}
         outputs.update({'indices': index})
-        if ann_path is None:
+        if ann is None:
             out = self.transform(image=img)
-            outputs.update({'pixel_values': out['image'], 'name': img_path.name, 'org_shape': (h, w)})
+            outputs.update({'pixel_values': out['image'], 'org_shape': (h, w)})
             return outputs
 
-        label, boxes_yolo = get_label(Path(ann_path))
+        label, boxes_yolo = ann
         boxes = self.xywhn2xyxy(boxes_yolo, w, h)
 
         out = self.transform(image=img, label=label, bbox=boxes, dataset=self)
@@ -84,7 +114,6 @@ class DetectionCustomDataset(BaseCustomDataset):
             return outputs
 
         assert self._split in ['val', 'valid', 'test']
-        # outputs.update({'org_img': org_img, 'org_shape': (h, w)})  # TODO: return org_img with batch_size > 1
         outputs.update({'org_shape': (h, w)})
         return outputs
 

--- a/src/netspresso_trainer/dataloaders/detection/local.py
+++ b/src/netspresso_trainer/dataloaders/detection/local.py
@@ -1,14 +1,14 @@
-from functools import partial
 import os
+from functools import partial
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import List
 
 import numpy as np
 import PIL.Image as Image
-from loguru import logger
-from multiprocessing.pool import ThreadPool
 import torch
 import torch.distributed as dist
+from loguru import logger
 from omegaconf import OmegaConf
 
 from ..base import BaseCustomDataset
@@ -85,7 +85,7 @@ class DetectionCustomDataset(BaseCustomDataset):
             img = self.samples[index]['image']
             ann = self.samples[index]['label']
         else:
-            img = Image.open(self.samples[index]['image']).convert('RGB')        
+            img = Image.open(self.samples[index]['image']).convert('RGB')
             ann_path = Path(self.samples[index]['label']) if self.samples[index]['label'] is not None else None
             ann = get_label(Path(ann_path)) if ann_path is not None else None
 

--- a/src/netspresso_trainer/dataloaders/pose_estimation/local.py
+++ b/src/netspresso_trainer/dataloaders/pose_estimation/local.py
@@ -1,15 +1,15 @@
-from functools import partial
 import os
+from functools import partial
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import List
-from multiprocessing.pool import ThreadPool
 
 import cv2
 import numpy as np
 import PIL.Image as Image
-from loguru import logger
 import torch
 import torch.distributed as dist
+from loguru import logger
 from omegaconf import OmegaConf
 
 from ..base import BaseCustomDataset

--- a/src/netspresso_trainer/dataloaders/segmentation/local.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/local.py
@@ -1,9 +1,12 @@
+from functools import partial
 import os
 from pathlib import Path
 from typing import Literal
+from multiprocessing.pool import ThreadPool
 
 import numpy as np
 import PIL.Image as Image
+from loguru import logger
 
 from ..augmentation.transforms import generate_edge, reduce_label
 from ..base import BaseCustomDataset
@@ -23,21 +26,48 @@ class SegmentationCustomDataset(BaseCustomDataset):
         self.label_image_mode: Literal['RGB', 'L', 'P'] = str(conf_data.label_image_mode).upper() \
             if conf_data.label_image_mode is not None else 'L'
 
+    def cache_dataset(self, sampler, distributed):
+        if (not distributed) or (distributed and dist.get_rank() == 0):
+            logger.info(f'Caching | Loading samples of {self.mode} to memory... This can take minutes.')
+
+        def _load(i, samples):
+            image = Image.open(Path(samples[i]['image'])).convert('RGB')
+            label = self.samples[i]['label']
+            if label is not None:
+                label = Image.open(Path(label)).convert(self.label_image_mode)
+            return i, image, label
+
+        num_threads = 8 # TODO: Compute appropriate num_threads
+        load_imgs = ThreadPool(num_threads).imap(
+            partial(_load, samples=self.samples),
+            sampler
+        )
+        for i, image, label in load_imgs:
+            self.samples[i]['image'] = image
+            self.samples[i]['label'] = label
+
+        self.cache = True
+
     def __getitem__(self, index):
-        img_path = Path(self.samples[index]['image'])
-        ann_path = Path(self.samples[index]['label']) if self.samples[index]['label'] is not None else None
-        img = Image.open(img_path).convert('RGB')
+        if self.cache:
+            img = self.samples[index]['image']
+            label = self.samples[index]['label']
+        else:
+            img_path = self.samples[index]['image']
+            ann_path = self.samples[index]['label']
+            img = Image.open(Path(img_path)).convert('RGB')
+            label = Image.open(Path(ann_path)).convert(self.label_image_mode) if ann_path is not None else None
 
         w, h = img.size
 
         outputs = {}
         outputs.update({'indices': index})
-        if ann_path is None:
+        if label is None:
             out = self.transform(image=img)
-            outputs.update({'pixel_values': out['image'], 'name': img_path.name, 'org_shape': (h, w)})
+            outputs.update({'pixel_values': out['image'], 'org_shape': (h, w)})
             return outputs
 
-        label = Image.open(ann_path).convert(self.label_image_mode)
+        
         label_array = np.array(label)
         label_array = label_array[..., np.newaxis] if label_array.ndim == 2 else label_array
         # if self.conf_augmentation.reduce_zero_label:
@@ -53,10 +83,10 @@ class SegmentationCustomDataset(BaseCustomDataset):
         if 'pidnet' in self.model_name:
             edge = generate_edge(np.array(mask))
             out = self.transform(image=img, mask=mask, edge=edge)
-            outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'edges': out['edge'].float(), 'name': img_path.name})
+            outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'edges': out['edge'].float()})
         else:
             out = self.transform(image=img, mask=mask)
-            outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'name': img_path.name})
+            outputs.update({'pixel_values': out['image'], 'labels': out['mask']})
 
         if self._split in ['train', 'training']:
             return outputs

--- a/src/netspresso_trainer/dataloaders/segmentation/local.py
+++ b/src/netspresso_trainer/dataloaders/segmentation/local.py
@@ -1,11 +1,12 @@
-from functools import partial
 import os
+from functools import partial
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
 from typing import Literal
-from multiprocessing.pool import ThreadPool
 
 import numpy as np
 import PIL.Image as Image
+import torch.distributed as dist
 from loguru import logger
 
 from ..augmentation.transforms import generate_edge, reduce_label
@@ -67,7 +68,7 @@ class SegmentationCustomDataset(BaseCustomDataset):
             outputs.update({'pixel_values': out['image'], 'org_shape': (h, w)})
             return outputs
 
-        
+
         label_array = np.array(label)
         label_array = label_array[..., np.newaxis] if label_array.ndim == 2 else label_array
         # if self.conf_augmentation.reduce_zero_label:

--- a/src/netspresso_trainer/dataloaders/utils/loader.py
+++ b/src/netspresso_trainer/dataloaders/utils/loader.py
@@ -84,12 +84,16 @@ def create_loader(
         worker_seeding='all',
         world_size=1,
         rank=0,
+        cache_data=False,
         kwargs=None
 ):
     if is_training:
         sampler = torch.utils.data.distributed.DistributedSampler(dataset, num_replicas=world_size, rank=rank, drop_last=True)
     else:
         sampler = DistributedEvalSampler(dataset, num_replicas=world_size, rank=rank)
+
+    if cache_data:
+        dataset.cache_dataset(sampler, distributed)
 
     loader_args = {
         'batch_size': batch_size,

--- a/src/netspresso_trainer/pipelines/builder.py
+++ b/src/netspresso_trainer/pipelines/builder.py
@@ -64,7 +64,7 @@ def build_pipeline(
 
     # Build task processor
     postprocessor = build_postprocessor(task, conf.model)
-    task_processor = TASK_PROCESSOR[task](conf, postprocessor, devices)
+    task_processor = TASK_PROCESSOR[task](conf, postprocessor, devices, num_classes=len(class_map))
 
     # Build timer
     timer = Timer()

--- a/src/netspresso_trainer/pipelines/task_processors/base.py
+++ b/src/netspresso_trainer/pipelines/task_processors/base.py
@@ -7,7 +7,7 @@ NUM_SAMPLES = 16
 
 
 class BaseTaskProcessor(ABC):
-    def __init__(self, conf, postprocessor, devices):
+    def __init__(self, conf, postprocessor, devices, **kwargs):
         super(BaseTaskProcessor, self).__init__()
         self.conf = conf
         self.postprocessor = postprocessor

--- a/src/netspresso_trainer/pipelines/task_processors/classification.py
+++ b/src/netspresso_trainer/pipelines/task_processors/classification.py
@@ -7,8 +7,8 @@ from .base import BaseTaskProcessor
 
 
 class ClassificationProcessor(BaseTaskProcessor):
-    def __init__(self, conf, postprocessor, devices):
-        super(ClassificationProcessor, self).__init__(conf, postprocessor, devices)
+    def __init__(self, conf, postprocessor, devices, **kwargs):
+        super(ClassificationProcessor, self).__init__(conf, postprocessor, devices, **kwargs)
 
     def train_step(self, train_model, batch, optimizer, loss_factory, metric_factory):
         train_model.train()

--- a/src/netspresso_trainer/pipelines/task_processors/detection.py
+++ b/src/netspresso_trainer/pipelines/task_processors/detection.py
@@ -6,10 +6,9 @@ from .base import BaseTaskProcessor
 
 
 class DetectionProcessor(BaseTaskProcessor):
-    def __init__(self, conf, postprocessor, devices):
-        super(DetectionProcessor, self).__init__(conf, postprocessor, devices)
-        self.num_classes = 4 # TODO: Fix this
-        #self.num_classes = train_dataloader.dataset.num_classes
+    def __init__(self, conf, postprocessor, devices, **kwargs):
+        super(DetectionProcessor, self).__init__(conf, postprocessor, devices, **kwargs)
+        self.num_classes = kwargs['num_classes']
 
     def train_step(self, train_model, batch, optimizer, loss_factory, metric_factory):
         train_model.train()

--- a/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
@@ -6,8 +6,8 @@ from .base import BaseTaskProcessor
 
 
 class PoseEstimationProcessor(BaseTaskProcessor):
-    def __init__(self, conf, postprocessor, devices):
-        super(PoseEstimationProcessor, self).__init__(conf, postprocessor, devices)
+    def __init__(self, conf, postprocessor, devices, **kwargs):
+        super(PoseEstimationProcessor, self).__init__(conf, postprocessor, devices, **kwargs)
 
     def train_step(self, train_model, batch, optimizer, loss_factory, metric_factory):
         train_model.train()

--- a/src/netspresso_trainer/pipelines/task_processors/segmentation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/segmentation.py
@@ -6,8 +6,8 @@ from .base import BaseTaskProcessor
 
 
 class SegmentationProcessor(BaseTaskProcessor):
-    def __init__(self, conf, postprocessor, devices):
-        super(SegmentationProcessor, self).__init__(conf, postprocessor, devices)
+    def __init__(self, conf, postprocessor, devices, **kwargs):
+        super(SegmentationProcessor, self).__init__(conf, postprocessor, devices, **kwargs)
 
     def train_step(self, train_model, batch, optimizer, loss_factory, metric_factory):
         train_model.train()


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #387

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Add dataset caching feature
  - If `environment.cache_data` is set as `True`, load entire dataset to memory before start training
  - Because `DistributedSampler` separate indices according to distributed rank, indices held by each process are not overlapped.
- Add `num_classes` parameter when creating `TaskProcessor`

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 