### PR TITLE
Specify input size for onnx export and remove augmentation.img_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Change ClassficationDataSampler logic by `@illian01` in [PR 382](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/382)
 - Add YOLOX weights initialization step by `@illian01` in [PR 393](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/393)
 - Minor update: detection postprocessor, dataset, and padding strategy by `@illian01` in [PR 395](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/395)
+- Specify input size for onnx export and remove augmentation.img_size by `@illian01` in [PR 399](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/399)
 
 # v0.1.2
 

--- a/config/augmentation/classification.yaml
+++ b/config/augmentation/classification.yaml
@@ -1,9 +1,8 @@
 augmentation:
-  img_size: &img_size 256
   train:
     - 
       name: randomresizedcrop
-      size: *img_size
+      size: 256
       scale: [0.08, 1.0]
       ratio: [0.75, 1.33]
       interpolation: bilinear
@@ -18,7 +17,7 @@ augmentation:
   inference:
     - 
       name: resize
-      size: [*img_size, *img_size]
+      size: [256, 256]
       interpolation: bilinear
       max_size: ~
       resize_criteria: ~

--- a/config/augmentation/detection.yaml
+++ b/config/augmentation/detection.yaml
@@ -1,16 +1,15 @@
 augmentation:
-  img_size: &img_size 512
   train:
     - 
       name: resize
-      size: [*img_size, *img_size]
+      size: [512, 512]
       interpolation: bilinear
       max_size: ~
       resize_criteria: ~
   inference:
     - 
       name: resize
-      size: [*img_size, *img_size]
+      size: [512, 512]
       interpolation: bilinear
       max_size: ~
       resize_criteria: ~

--- a/config/augmentation/pose_estimation.yaml
+++ b/config/augmentation/pose_estimation.yaml
@@ -12,7 +12,7 @@ augmentation:
       translate_prob: 1.
       rotation: 60
       rotation_prob: 1.
-      size: [*img_size, *img_size]
+      size: [256, 256]
   inference:
     - 
       name: posetopdownaffine
@@ -22,4 +22,4 @@ augmentation:
       translate_prob: 0.
       rotation: 0
       rotation_prob: 0.
-      size: [*img_size, *img_size]
+      size: [256, 256]

--- a/config/augmentation/segmentation.yaml
+++ b/config/augmentation/segmentation.yaml
@@ -3,7 +3,7 @@ augmentation:
   train:
     - 
       name: randomresizedcrop
-      size: *img_size
+      size: 512
       scale: [0.08, 1.0]
       ratio: [0.75, 1.33]
       interpolation: bilinear
@@ -20,7 +20,7 @@ augmentation:
   inference:
     - 
       name: resize
-      size: [*img_size, *img_size]
+      size: [512, 512]
       interpolation: bilinear
       max_size: ~
       resize_criteria: ~

--- a/config/augmentation/template/common.yaml
+++ b/config/augmentation/template/common.yaml
@@ -1,5 +1,4 @@
 augmentation:
-  img_size: &img_size ~
   train:
     - 
       name: randomresizedcrop

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -5,5 +5,6 @@ logging:
   image: true
   stdout: true
   save_optimizer_state: true
+  onnx_input_size: [512, 512]
   validation_epoch: &validation_epoch 10
   save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.

--- a/config/model/segformer/segformer-b0-segmentation.yaml
+++ b/config/model/segformer/segformer-b0-segmentation.yaml
@@ -51,6 +51,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+        resize_output: [512, 512]
   losses:
     - criterion: cross_entropy
       weight: ~

--- a/src/netspresso_trainer/dataloaders/augmentation/transforms.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/transforms.py
@@ -41,7 +41,6 @@ def transforms_check(transforms):
 
 
 def transforms_custom(conf_augmentation, training):
-    assert conf_augmentation.img_size > 32
     phase_conf = conf_augmentation.train if training else conf_augmentation.inference
 
     preprocess = []

--- a/src/netspresso_trainer/dataloaders/builder.py
+++ b/src/netspresso_trainer/dataloaders/builder.py
@@ -124,7 +124,6 @@ def build_dataloader(conf, task: str, model_name: str, dataset, phase, profile=F
             dataset,
             conf.data.name,
             logger,
-            input_size=conf.augmentation.img_size,
             batch_size=conf.environment.batch_size,
             is_training=is_training,
             num_workers=conf.environment.num_workers if not profile else 1,

--- a/src/netspresso_trainer/dataloaders/utils/loader.py
+++ b/src/netspresso_trainer/dataloaders/utils/loader.py
@@ -68,7 +68,6 @@ def create_loader(
         dataset,
         dataset_name,
         logger,
-        input_size=None,
         batch_size=1,
         is_training=False,
         num_aug_repeats=0,

--- a/src/netspresso_trainer/evaluator_common.py
+++ b/src/netspresso_trainer/evaluator_common.py
@@ -58,7 +58,6 @@ def evaluation_common(
         conf.model, task, test_dataset.num_classes,
         model_checkpoint=conf.model.checkpoint.path,
         use_pretrained=conf.model.checkpoint.use_pretrained,
-        img_size=conf.augmentation.img_size
     )
 
     model = model.to(device=devices)

--- a/src/netspresso_trainer/inferencer_common.py
+++ b/src/netspresso_trainer/inferencer_common.py
@@ -62,7 +62,6 @@ def inference_common(
         conf.model, task, test_dataset.num_classes,
         model_checkpoint=conf.model.checkpoint.path,
         use_pretrained=conf.model.checkpoint.use_pretrained,
-        img_size=conf.augmentation.img_size
     )
 
     model = model.to(device=devices)

--- a/src/netspresso_trainer/losses/common.py
+++ b/src/netspresso_trainer/losses/common.py
@@ -8,7 +8,7 @@ from torch import Tensor
 
 class CrossEntropyLoss(nn.Module):
     def __init__(self, weight: Optional[Tensor]=None, size_average=None, ignore_index: int=-100,
-                 reduce=None, label_smoothing: float=0.0):
+                 reduce=None, label_smoothing: float=0.0, **kwargs):
         super(CrossEntropyLoss, self).__init__()
         self.loss_fn = nn.CrossEntropyLoss(weight=weight, size_average=size_average, ignore_index=ignore_index,
                                            reduce=reduce, reduction='mean', label_smoothing=label_smoothing)
@@ -21,7 +21,7 @@ class CrossEntropyLoss(nn.Module):
 
 
 class SigmoidFocalLoss(nn.Module):
-    def __init__(self, alpha, gamma):
+    def __init__(self, alpha, gamma, **kwargs):
         super(SigmoidFocalLoss, self).__init__()
         self.alpha = alpha
         self.gamma = gamma

--- a/src/netspresso_trainer/losses/detection/retinanet.py
+++ b/src/netspresso_trainer/losses/detection/retinanet.py
@@ -11,7 +11,7 @@ from ..common import SigmoidFocalLoss
 
 
 class RetinaNetLoss(nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, **kwargs) -> None:
         super().__init__()
         fg_iou_thresh = 0.5
         bg_iou_thresh = 0.4

--- a/src/netspresso_trainer/losses/pose_estimation/rtmcc.py
+++ b/src/netspresso_trainer/losses/pose_estimation/rtmcc.py
@@ -17,7 +17,7 @@ from ..common import SigmoidFocalLoss
 
 
 class RTMCCLoss(nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, **kwargs) -> None:
         super().__init__()
         # TODO: Get from config
         self.beta = 10.

--- a/src/netspresso_trainer/losses/segmentation/pidnet.py
+++ b/src/netspresso_trainer/losses/segmentation/pidnet.py
@@ -135,7 +135,7 @@ class BoundaryLoss(nn.Module):
 
 
 class PIDNetLoss(nn.Module):
-    def __init__(self, ignore_index=IGNORE_INDEX_NONE_VALUE, weight=None):
+    def __init__(self, ignore_index=IGNORE_INDEX_NONE_VALUE, weight=None, **kwargs):
         super().__init__()
 
         self.cross_entropy_loss = PIDNetCrossEntropy(ignore_index=ignore_index)

--- a/src/netspresso_trainer/metrics/builder.py
+++ b/src/netspresso_trainer/metrics/builder.py
@@ -14,6 +14,9 @@ class MetricFactory:
         assert self.task in TASK_METRIC
         self.metric_cls = TASK_METRIC[self.task]
 
+        # TODO: This code assumes there is only one loss module. Fix here later.
+        if hasattr(conf_model.losses[0], 'ignore_index'):
+            kwargs['ignore_index'] = conf_model.losses[0].ignore_index 
         self.metric_fn = self.metric_cls(**kwargs)
         self._clear_epoch_start()
 

--- a/src/netspresso_trainer/metrics/builder.py
+++ b/src/netspresso_trainer/metrics/builder.py
@@ -16,7 +16,7 @@ class MetricFactory:
 
         # TODO: This code assumes there is only one loss module. Fix here later.
         if hasattr(conf_model.losses[0], 'ignore_index'):
-            kwargs['ignore_index'] = conf_model.losses[0].ignore_index 
+            kwargs['ignore_index'] = conf_model.losses[0].ignore_index
         self.metric_fn = self.metric_cls(**kwargs)
         self._clear_epoch_start()
 

--- a/src/netspresso_trainer/models/builder.py
+++ b/src/netspresso_trainer/models/builder.py
@@ -35,7 +35,6 @@ def load_full_model(conf_model, model_name, num_classes, model_checkpoint, use_p
 def load_backbone_and_head_model(
         conf_model, task, backbone_name, head_name, num_classes,
         model_checkpoint, use_pretrained, freeze_backbone,
-        img_size
     ):
     if task not in TASK_MODEL_DICT:
         raise ValueError(
@@ -59,10 +58,8 @@ def load_backbone_and_head_model(
     if task == 'classification':
         head = head_module(num_classes=num_classes, feature_dim=backbone.feature_dim, conf_model_head=conf_model.architecture.head)
     elif task in ['segmentation', 'detection', 'pose_estimation']:
-        img_size = img_size if isinstance(img_size, (int, None)) else tuple(img_size)
         head = head_module(num_classes=num_classes,
                                 intermediate_features_dim=intermediate_features_dim,
-                                label_size=img_size,
                                 conf_model_head=conf_model.architecture.head)
 
     # Assemble model and load checkpoint
@@ -75,7 +72,7 @@ def load_backbone_and_head_model(
     return model
 
 
-def build_model(conf_model, task, num_classes, model_checkpoint, use_pretrained, img_size) -> nn.Module:
+def build_model(conf_model, task, num_classes, model_checkpoint, use_pretrained) -> nn.Module:
 
     if conf_model.single_task_model:
         model_name = str(conf_model.architecture.full.name).lower()
@@ -93,5 +90,4 @@ def build_model(conf_model, task, num_classes, model_checkpoint, use_pretrained,
         model_checkpoint=model_checkpoint,
         use_pretrained=use_pretrained,
         freeze_backbone=freeze_backbone,
-        img_size=img_size
     )

--- a/src/netspresso_trainer/models/heads/segmentation/experimental/all_mlp_decoder.py
+++ b/src/netspresso_trainer/models/heads/segmentation/experimental/all_mlp_decoder.py
@@ -15,12 +15,12 @@ class AllMLPDecoder(nn.Module):
             self,
             num_classes: int,
             intermediate_features_dim: List[int],
-            label_size: Union[Tuple[int, int], int],
             params: DictConfig,
         ):
         super().__init__()
         intermediate_channels = params.intermediate_channels
         classifier_dropout_prob = params.classifier_dropout_prob
+        self.label_size = params.resize_output
 
         # linear layers which will unify the channel dimension of each of the encoder blocks to the same config.decoder_hidden_size
         mlps = []
@@ -37,8 +37,6 @@ class AllMLPDecoder(nn.Module):
 
         self.dropout = nn.Dropout(classifier_dropout_prob)
         self.classifier = nn.Conv2d(intermediate_channels, num_classes, kernel_size=1)
-
-        self.label_size = (label_size, label_size) if isinstance(label_size, int) else label_size
 
     def forward(self, encoder_hidden_states: FXTensorListType):
 
@@ -69,8 +67,7 @@ class AllMLPDecoder(nn.Module):
         return ModelOutput(pred=logits)
 
 
-def all_mlp_decoder(num_classes, intermediate_features_dim, label_size, conf_model_head, **kwargs) -> AllMLPDecoder:
+def all_mlp_decoder(num_classes, intermediate_features_dim, conf_model_head, **kwargs) -> AllMLPDecoder:
     return AllMLPDecoder(num_classes,
                          intermediate_features_dim,
-                         label_size=label_size,
                          params=conf_model_head.params)

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -33,7 +33,7 @@ class BasePipeline(ABC):
 
     @property
     def sample_input(self):
-        return torch.randn((1, 3, self.conf.augmentation.img_size, self.conf.augmentation.img_size))
+        return torch.randn((1, 3, self.conf.logging.onnx_input_size[0], self.conf.logging.onnx_input_size[1]))
 
     def log_results(
         self,

--- a/src/netspresso_trainer/pipelines/builder.py
+++ b/src/netspresso_trainer/pipelines/builder.py
@@ -126,8 +126,8 @@ def build_pipeline(
         eval_dataloader: DataLoader = dataloaders['test']
 
         # Build modules for evaluation
-        loss_factory = build_losses(conf.model, ignore_index=ignore_index)
-        metric_factory = build_metrics(task, conf.model, ignore_index=ignore_index, num_classes=eval_dataloader.dataset.num_classes)
+        loss_factory = build_losses(conf.model)
+        metric_factory = build_metrics(task, conf.model, num_classes=eval_dataloader.dataset.num_classes)
 
         # Build logger
         single_gpu_or_rank_zero = (not conf.distributed) or (conf.distributed and dist.get_rank() == 0)

--- a/src/netspresso_trainer/pipelines/builder.py
+++ b/src/netspresso_trainer/pipelines/builder.py
@@ -21,8 +21,6 @@ from ..utils.record import Timer
 from .registry import PIPELINES, SUPPORTING_TASK_LIST, TASK_PROCESSOR
 from .train import NUM_SAMPLES
 
-CITYSCAPE_IGNORE_INDEX = 255
-
 
 def load_optimizer_checkpoint(conf, optimizer, scheduler):
     start_epoch = 1
@@ -69,9 +67,6 @@ def build_pipeline(
     # Build timer
     timer = Timer()
 
-    # TODO: Temporarily set constant value of ignore_index
-    ignore_index = CITYSCAPE_IGNORE_INDEX if task == 'segmentation' else None
-
     if pipeline_type == 'train':
         train_dataloader: DataLoader = dataloaders['train']
         eval_dataloader: DataLoader = dataloaders['valid']
@@ -87,8 +82,8 @@ def build_pipeline(
         train_dataloader.dataset.end_epoch = conf.training.epochs
 
         # Build loss and metric modules
-        loss_factory = build_losses(conf.model, ignore_index=ignore_index, cur_epoch=cur_epoch)
-        metric_factory = build_metrics(task, conf.model, ignore_index=ignore_index, num_classes=train_dataloader.dataset.num_classes)
+        loss_factory = build_losses(conf.model, cur_epoch=cur_epoch)
+        metric_factory = build_metrics(task, conf.model, num_classes=train_dataloader.dataset.num_classes)
 
         # Set model EMA
         model_ema = None

--- a/src/netspresso_trainer/trainer_common.py
+++ b/src/netspresso_trainer/trainer_common.py
@@ -69,7 +69,6 @@ def train_common(
             conf.model, task, train_dataset.num_classes,
             model_checkpoint=conf.model.checkpoint.path,
             use_pretrained=conf.model.checkpoint.use_pretrained,
-            img_size=conf.augmentation.img_size
         )
 
     model = model.to(device=devices)


### PR DESCRIPTION
## Description

Please include a summary in English, of the changes in this pull request. If it closes an issue, please mention it here.

Closes: #369 

You should link at least one existing issue for PR. Before your create a PR, please check to see if there is an issue for this change.  
PRs from forked repository not accepted.

## Change(s)

- Specify input size for onnx export
- Remove `augmentation.img_size`
- Fix AllMLPDecoder to take `resize_output` field

## Changelog

If you PR to `dev` branch, please add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file and include a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 