### PR TITLE
Refactoring metric modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Gather predicted results before compute metric and fix additional distributed evaluation inaccurate error by `@illian01` in [PR 346](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/346), [PR 356](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/356)
 - Fix detection score return by `@illian01` in [PR 373](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/373)
 - Fix memory leak from onnx export by `@illian01` in [PR 386](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/386), [PR 394](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/394)
+- Refactoring metric modules and fix inaccurate metric bug by `@illian01` in [PR 402](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/402)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/metrics/base.py
+++ b/src/netspresso_trainer/metrics/base.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Dict, List
 
 from ..utils.record import MetricMeter
 

--- a/src/netspresso_trainer/metrics/base.py
+++ b/src/netspresso_trainer/metrics/base.py
@@ -1,13 +1,14 @@
-from typing import List
+from typing import List, Dict
+
+from ..utils.record import MetricMeter
 
 
 class BaseMetric:
-    metric_names: List[str] = ['']
-    primary_metric: str = ''
-
-    def __init__(self, **kwargs):
-        assert self.primary_metric in self.metric_names
-        pass
+    def __init__(self, metric_names, primary_metric, **kwargs):
+        assert primary_metric in metric_names
+        self.metric_names = metric_names
+        self.primary_metric = primary_metric
+        self.metric_meter = {metric_name: MetricMeter(metric_name, ':6.2f') for metric_name in metric_names}
 
     def calibrate(self, pred, target, **kwargs):
         pass

--- a/src/netspresso_trainer/metrics/builder.py
+++ b/src/netspresso_trainer/metrics/builder.py
@@ -22,10 +22,7 @@ class MetricFactory:
         for phase in PHASE_LIST:
             [meter.reset() for _, meter in self.metrics[phase].metric_meter.items()]
 
-    def calc(self, pred: torch.Tensor, target: torch.Tensor, phase='train', **kwargs: Any) -> None:
-        self.__call__(pred=pred, target=target, phase=phase, **kwargs)
-
-    def __call__(self, pred: torch.Tensor, target: torch.Tensor, phase: str, **kwargs: Any) -> None:
+    def update(self, pred: torch.Tensor, target: torch.Tensor, phase: str, **kwargs: Any) -> None:
         if len(pred) == 0: # Removed dummy batch has 0 len
             return
         phase = phase.lower()

--- a/src/netspresso_trainer/metrics/builder.py
+++ b/src/netspresso_trainer/metrics/builder.py
@@ -2,7 +2,6 @@ from typing import Any, Dict
 
 import torch
 
-from ..utils.record import AverageMeter
 from .registry import PHASE_LIST, TASK_METRIC
 
 
@@ -17,20 +16,11 @@ class MetricFactory:
         # TODO: This code assumes there is only one loss module. Fix here later.
         if hasattr(conf_model.losses[0], 'ignore_index'):
             kwargs['ignore_index'] = conf_model.losses[0].ignore_index
-        self.metric_fn = self.metric_cls(**kwargs)
-        self._clear_epoch_start()
-
-    def _clear_epoch_start(self):
-        self.metric_meter_dict: Dict[str, Dict[str, AverageMeter]] = {
-            phase: {
-                metric_key: AverageMeter(metric_key, ':6.2f')
-                for metric_key in self.metric_cls.metric_names
-            }
-            for phase in PHASE_LIST
-        }
+        self.metrics = {phase: self.metric_cls(**kwargs) for phase in PHASE_LIST}
 
     def reset_values(self):
-        self._clear_epoch_start()
+        for phase in PHASE_LIST:
+            [meter.reset() for _, meter in self.metrics[phase].metric_meter.items()]
 
     def calc(self, pred: torch.Tensor, target: torch.Tensor, phase='train', **kwargs: Any) -> None:
         self.__call__(pred=pred, target=target, phase=phase, **kwargs)
@@ -38,23 +28,19 @@ class MetricFactory:
     def __call__(self, pred: torch.Tensor, target: torch.Tensor, phase: str, **kwargs: Any) -> None:
         if len(pred) == 0: # Removed dummy batch has 0 len
             return
-        metric_result_dict = self.metric_fn.calibrate(pred, target)
         phase = phase.lower()
-        assert phase in PHASE_LIST, f"{phase} is not defined at our phase list ({PHASE_LIST})"
-        for metric_key in self.metric_meter_dict[phase]:
-            assert metric_key in metric_result_dict
-            self.metric_meter_dict[phase][metric_key].update(float(metric_result_dict[metric_key]))
+        self.metrics[phase].calibrate(pred, target)
 
     def result(self, phase='train'):
-        return self.metric_meter_dict[phase.lower()]
+        return {metric_name: meter.avg for metric_name, meter in self.metrics[phase].metric_meter.items()}
 
     @property
     def metric_names(self):
-        return self.metric_fn.metric_names
+        return self.metrics[list(self.metrics.keys())[0]].metric_names
 
     @property
     def primary_metric(self):
-        return self.metric_fn.primary_metric
+        return self.metrics[list(self.metrics.keys())[0]].primary_metric
 
 
 def build_metrics(task: str, conf_model, **kwargs) -> MetricFactory:

--- a/src/netspresso_trainer/metrics/classification/metric.py
+++ b/src/netspresso_trainer/metrics/classification/metric.py
@@ -16,20 +16,25 @@ def accuracy_topk(pred, target):
     pred = pred.T
     class_num = pred.shape[0]
     correct = np.equal(pred, np.tile(target, (class_num, 1)))
-    return lambda topk: correct[:min(topk, maxk)].reshape(-1).astype('float').sum(0) * 100. / batch_size
+    return lambda topk: correct[:min(topk, maxk)].reshape(-1).astype('float').sum(0)
 
 
 class ClassificationMetric(BaseMetric):
-    metric_names: List[str] = ['Acc@1', 'Acc@5']
-    primary_metric: str = 'Acc@1'
+    SUPPORT_METRICS: List[str] = ['Acc@1', 'Acc@5']
 
     def __init__(self, **kwargs):
-        super().__init__()
+        # TODO: Select metrics by user
+        metric_names = ['Acc@1', 'Acc@5']
+        primary_metric = 'Acc@1'
+
+        assert set(metric_names).issubset(ClassificationMetric.SUPPORT_METRICS)
+        super().__init__(metric_names=metric_names, primary_metric=primary_metric)
 
     def calibrate(self, pred, target, **kwargs):
-        result_dict = {k: 0. for k in self.metric_names}
         topk_callable = accuracy_topk(pred, target)
 
-        result_dict['Acc@1'] = topk_callable(topk=1)
-        result_dict['Acc@5'] = topk_callable(topk=5)
-        return result_dict
+        Acc1_correct = topk_callable(topk=1)
+        Acc5_correct = topk_callable(topk=5)
+
+        self.metric_meter['Acc@1'].update(Acc1_correct, n=pred.shape[0])
+        self.metric_meter['Acc@5'].update(Acc5_correct, n=pred.shape[0])

--- a/src/netspresso_trainer/metrics/classification/metric.py
+++ b/src/netspresso_trainer/metrics/classification/metric.py
@@ -11,7 +11,6 @@ TOPK_MAX = 20
 @torch.no_grad()
 def accuracy_topk(pred, target):
     """Computes the accuracy over the k top predictions for the specified values of k"""
-    batch_size = target.shape[0]
     maxk = pred.shape[-1]
     pred = pred.T
     class_num = pred.shape[0]

--- a/src/netspresso_trainer/metrics/detection/metric.py
+++ b/src/netspresso_trainer/metrics/detection/metric.py
@@ -171,7 +171,7 @@ class DetectionMetric(BaseMetric):
         # TODO: Select metrics by user
         metric_names: List[str] = ['map50', 'map75', 'map50_95']
         primary_metric: str = 'map50'
-        assert set(metric_names).issubset(DetectionMetric.SUPPORT_METRICS) 
+        assert set(metric_names).issubset(DetectionMetric.SUPPORT_METRICS)
         super().__init__(metric_names=metric_names, primary_metric=primary_metric)
 
     def calibrate(self, predictions, targets, **kwargs):

--- a/src/netspresso_trainer/metrics/detection/metric.py
+++ b/src/netspresso_trainer/metrics/detection/metric.py
@@ -165,11 +165,14 @@ def average_precisions_per_class(
 
 
 class DetectionMetric(BaseMetric):
-    metric_names: List[str] = ['map50', 'map75', 'map50_95']
-    primary_metric: str = 'map50'
+    SUPPORT_METRICS: List[str] = ['map50', 'map75', 'map50_95']
 
     def __init__(self, **kwargs):
-        super().__init__()
+        # TODO: Select metrics by user
+        metric_names: List[str] = ['map50', 'map75', 'map50_95']
+        primary_metric: str = 'map50'
+        assert set(metric_names).issubset(DetectionMetric.SUPPORT_METRICS) 
+        super().__init__(metric_names=metric_names, primary_metric=primary_metric)
 
     def calibrate(self, predictions, targets, **kwargs):
         result_dict = {k: 0. for k in self.metric_names}
@@ -209,11 +212,16 @@ class DetectionMetric(BaseMetric):
         if stats:
             concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
             average_precisions = average_precisions_per_class(*concatenated_stats)
-            result_dict['map50'] = average_precisions[:, 0].mean()
-            result_dict['map75'] = average_precisions[:, 5].mean()
-            result_dict['map50_95'] = average_precisions.mean()
+            #result_dict['map50'] = average_precisions[:, 0].mean()
+            #result_dict['map75'] = average_precisions[:, 5].mean()
+            #result_dict['map50_95'] = average_precisions.mean()
+            self.metric_meter['map50'].update(average_precisions[:, 0].mean())
+            self.metric_meter['map75'].update(average_precisions[:, 5].mean())
+            self.metric_meter['map50_95'].update(average_precisions.mean())
         else:
-            result_dict['map50'], result_dict['map75'], result_dict['map50_95'] = 0, 0, 0
-            average_precisions = []
+            #result_dict['map50'], result_dict['map75'], result_dict['map50_95'] = 0, 0, 0
+            self.metric_meter['map50'].update(0)
+            self.metric_meter['map75'].update(0)
+            self.metric_meter['map50_95'].update(0)
 
         return result_dict

--- a/src/netspresso_trainer/metrics/pose_estimation/metric.py
+++ b/src/netspresso_trainer/metrics/pose_estimation/metric.py
@@ -9,6 +9,7 @@ class PoseEstimationMetric(BaseMetric):
     SUPPORT_METRICS: List[str] = ['pck']
 
     def __init__(self, **kwargs):
+        # TODO: Select metrics by user
         metric_names: List[str] = ['pck']
         primary_metric: str = 'pck'
 

--- a/src/netspresso_trainer/metrics/pose_estimation/metric.py
+++ b/src/netspresso_trainer/metrics/pose_estimation/metric.py
@@ -1,17 +1,19 @@
 from typing import List
 
 import numpy as np
-import torch
 
 from ..base import BaseMetric
 
 
 class PoseEstimationMetric(BaseMetric):
-    metric_names: List[str] = ['pck']
-    primary_metric: str = 'pck'
+    SUPPORT_METRICS: List[str] = ['pck']
 
     def __init__(self, **kwargs):
-        super().__init__()
+        metric_names: List[str] = ['pck']
+        primary_metric: str = 'pck'
+
+        assert set(metric_names).issubset(PoseEstimationMetric.SUPPORT_METRICS) 
+        super().__init__(metric_names=metric_names, primary_metric=primary_metric)
         # TODO: Get from config
         self.thr = 0.05
         self.input_size = (256, 256)
@@ -45,8 +47,6 @@ class PoseEstimationMetric(BaseMetric):
         return acc, avg_acc, cnt
 
     def calibrate(self, pred, target, **kwargs):
-        result_dict = {k: 0. for k in self.metric_names}
-
         N, _, _ = pred.shape
 
         mask = target[..., 2] > 0
@@ -58,6 +58,4 @@ class PoseEstimationMetric(BaseMetric):
         normalize = np.tile(np.array([[self.input_size[0], self.input_size[1]]]), (N, 1))
 
         acc, avg_acc, cnt = self.keypoint_pck_accuracy(pred, target, mask, self.thr, normalize)
-        result_dict['pck'] = avg_acc
-
-        return result_dict
+        self.metric_meter['pck'].update(avg_acc)

--- a/src/netspresso_trainer/metrics/pose_estimation/metric.py
+++ b/src/netspresso_trainer/metrics/pose_estimation/metric.py
@@ -13,7 +13,7 @@ class PoseEstimationMetric(BaseMetric):
         metric_names: List[str] = ['pck']
         primary_metric: str = 'pck'
 
-        assert set(metric_names).issubset(PoseEstimationMetric.SUPPORT_METRICS) 
+        assert set(metric_names).issubset(PoseEstimationMetric.SUPPORT_METRICS)
         super().__init__(metric_names=metric_names, primary_metric=primary_metric)
         # TODO: Get from config
         self.thr = 0.05

--- a/src/netspresso_trainer/metrics/segmentation/metric.py
+++ b/src/netspresso_trainer/metrics/segmentation/metric.py
@@ -15,7 +15,7 @@ class SegmentationMetric(BaseMetric):
         metric_names = ['iou', 'pixel_acc']
         primary_metric = 'iou'
 
-        assert set(metric_names).issubset(SegmentationMetric.SUPPORT_METRICS) 
+        assert set(metric_names).issubset(SegmentationMetric.SUPPORT_METRICS)
         super().__init__(metric_names=metric_names, primary_metric=primary_metric)
         self.ignore_index = ignore_index if ignore_index is not None else IGNORE_INDEX_NONE_VALUE
         self.K = num_classes

--- a/src/netspresso_trainer/pipelines/task_processors/classification.py
+++ b/src/netspresso_trainer/pipelines/task_processors/classification.py
@@ -39,9 +39,9 @@ class ClassificationProcessor(BaseTaskProcessor):
             torch.distributed.gather_object(labels, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                [metric_factory.calc(g_pred, g_labels, phase='train') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
+                [metric_factory.update(g_pred, g_labels, phase='train') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
         else:
-            metric_factory.calc(pred, labels, phase='train')
+            metric_factory.update(pred, labels, phase='train')
 
     def valid_step(self, eval_model, batch, loss_factory, metric_factory):
         eval_model.eval()
@@ -69,9 +69,9 @@ class ClassificationProcessor(BaseTaskProcessor):
             torch.distributed.gather_object(labels, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                [metric_factory.calc(g_pred, g_labels, phase='valid') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
+                [metric_factory.update(g_pred, g_labels, phase='valid') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
         else:
-            metric_factory.calc(pred, labels, phase='valid')
+            metric_factory.update(pred, labels, phase='valid')
 
         if self.single_gpu_or_rank_zero:
             results = {

--- a/src/netspresso_trainer/pipelines/task_processors/detection.py
+++ b/src/netspresso_trainer/pipelines/task_processors/detection.py
@@ -164,4 +164,4 @@ class DetectionProcessor(BaseTaskProcessor):
                     pred_on_image['post_scores'] = detection[..., -1]
                     pred_on_image['post_labels'] = class_idx
                     pred.append(pred_on_image)
-            metric_factory.calc(pred, target=targets, phase=phase)
+            metric_factory.update(pred, target=targets, phase=phase)

--- a/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
-import torch
 import numpy as np
+import torch
 
 from .base import BaseTaskProcessor
 
@@ -39,7 +39,7 @@ class PoseEstimationProcessor(BaseTaskProcessor):
             if torch.distributed.get_rank() == 0:
                 pred = np.concatenate(gathered_pred, axis=0)
                 keypoints = np.concatenate(gathered_labels, axis=0)
-        
+
         if self.single_gpu_or_rank_zero:
             logs = {
                 'target': keypoints,
@@ -80,7 +80,7 @@ class PoseEstimationProcessor(BaseTaskProcessor):
                 'target': keypoints,
                 'pred': pred
             }
-            return dict(logs.items())            
+            return dict(logs.items())
 
     def test_step(self, test_model, batch):
         test_model.eval()

--- a/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
@@ -36,9 +36,9 @@ class PoseEstimationProcessor(BaseTaskProcessor):
             torch.distributed.gather_object(keypoints, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                [metric_factory.calc(g_pred, g_labels, phase='train') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
+                [metric_factory.update(g_pred, g_labels, phase='train') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
         else:
-            metric_factory.calc(pred, keypoints, phase='train')
+            metric_factory.update(pred, keypoints, phase='train')
 
     def valid_step(self, eval_model, batch, loss_factory, metric_factory):
         eval_model.eval()
@@ -64,9 +64,9 @@ class PoseEstimationProcessor(BaseTaskProcessor):
             torch.distributed.gather_object(keypoints, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                [metric_factory.calc(g_pred, g_labels, phase='valid') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
+                [metric_factory.update(g_pred, g_labels, phase='valid') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
         else:
-            metric_factory.calc(pred, keypoints, phase='valid')
+            metric_factory.update(pred, keypoints, phase='valid')
 
         # TODO: Return gathered samples
         logs = {

--- a/src/netspresso_trainer/pipelines/task_processors/segmentation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/segmentation.py
@@ -42,9 +42,9 @@ class SegmentationProcessor(BaseTaskProcessor):
             torch.distributed.gather_object(labels, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                [metric_factory.calc(g_pred, g_labels, phase='train') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
+                [metric_factory.update(g_pred, g_labels, phase='train') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
         else:
-            metric_factory.calc(pred, labels, phase='train')
+            metric_factory.update(pred, labels, phase='train')
 
     def valid_step(self, eval_model, batch, loss_factory, metric_factory):
         eval_model.eval()
@@ -75,9 +75,9 @@ class SegmentationProcessor(BaseTaskProcessor):
             torch.distributed.gather_object(labels, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                [metric_factory.calc(g_pred, g_labels, phase='valid') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
+                [metric_factory.update(g_pred, g_labels, phase='valid') for g_pred, g_labels in zip(gathered_pred, gathered_labels)]
         else:
-            metric_factory.calc(pred, labels, phase='valid')
+            metric_factory.update(pred, labels, phase='valid')
 
         logs = {
             'images': images.detach().cpu().numpy(),

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -248,7 +248,8 @@ class TrainingPipeline(BasePipeline):
         best_checkpoint_path = Path(logging_dir) / f"{self.task}_{self.model_name}_epoch_{best_epoch}.ext"
         best_model_save_path = Path(logging_dir) / f"{self.task}_{self.model_name}_best.ext"
 
-        best_model_to_save = copy.deepcopy(self.model)
+        model = self.model.module if hasattr(self.model, 'module') else self.model
+        best_model_to_save = copy.deepcopy(model)
 
         if self.is_graphmodule_training:
             best_model_to_save.load_state_dict(load_checkpoint(best_checkpoint_path.with_suffix('.pt')).state_dict())

--- a/src/netspresso_trainer/utils/record.py
+++ b/src/netspresso_trainer/utils/record.py
@@ -34,6 +34,35 @@ class AverageMeter(object):
         return self._avg
 
 
+class MetricMeter(object):
+    """Computes and stores the average and current value"""
+
+    def __init__(self, name: str, fmt=':f'):
+        self.name = name
+        self.fmt = fmt
+        self.reset()
+
+    def reset(self):
+        self._val: float = 0.
+        self._avg: float = 0.
+        self._sum: float = 0.
+        self._count: int = 0
+
+    def update(self, val: Union[float, int], n: int = 1) -> None:
+        self._val = val
+        self._sum += val
+        self._count += n
+        self._avg = self._sum / self._count
+
+    def __str__(self):
+        fmtstr = '{name} {val' + self.fmt + '} ({avg' + self.fmt + '})'
+        return fmtstr.format(**self.__dict__)
+
+    @property
+    def avg(self) -> float:
+        return self._avg
+
+
 class TimeRecode:
     def __init__(self) -> None:
         self._start = time.time()


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #360 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Refactoring metric modules
  - Add `MetricMeter`: `AverageMeter` is not fit with metric modules
  - `BaseMetric` has `MetricMeter` as attribute: Thus, `AverageMeter` in `MetricFactory` has removed.
- Refactoring pose estimation processor
  - Now, pose estimation metric computing is done in `get_metric_with_all_outputs`
- [hotfix] Check ddp module when try to save best model

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```