### PR TITLE
[hotfix] Eval and Infer don't have training conf

### DIFF
--- a/src/netspresso_trainer/pipelines/task_processors/base.py
+++ b/src/netspresso_trainer/pipelines/task_processors/base.py
@@ -17,7 +17,10 @@ class BaseTaskProcessor(ABC):
         self.single_gpu_or_rank_zero = (not conf.distributed) or (conf.distributed and dist.get_rank() == 0)
 
         #TODO: Temporarily set ``mixed_precision`` as optional since this is experimental
-        self.mixed_precision = conf.training.mixed_precision if hasattr(conf.training, 'mixed_precision') else False
+        if hasattr(conf, 'training'):
+            self.mixed_precision = conf.training.mixed_precision if hasattr(conf.training, 'mixed_precision') else False
+        else:
+            self.mixed_precision = False
         if self.mixed_precision:
             if self.single_gpu_or_rank_zero:
                 logger.info("Mixed precision training activated.")


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #(issue number)

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Fix `mixed_precision` attribute initialization in `TaskProcessor`

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```