### PR TITLE
Save training summary at every end of epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ No changes to highlight.
 
 ## Other Changes:
 
-No changes to highlight.
+- Save training summary at every end of epochs by `@illian01` in [PR 420](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/420)
 
 # v0.2.0
 

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -137,10 +137,10 @@ class TrainingPipeline(BasePipeline):
                                        time_for_epoch=time_for_epoch,
                                        valid_samples=valid_samples,
                                        valid_logging=with_valid_logging)
+                    self.save_summary()
                     if with_checkpoint_saving:
                         assert with_valid_logging
                         self.save_checkpoint(epoch=num_epoch)
-                        self.save_summary()
                     logger.info("-" * 40)
 
                 self.scheduler.step()  # call after reporting the current `learning_rate`


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #403

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Save training summary at every end of epochs.
- Since we use `json.dump` to save summary, the summary file will be newly written on each method call.

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```