### PR TITLE
Refactoring FPN module to make more flexible

### DIFF
--- a/config/model/efficientformer/efficientformer-l1-detection.yaml
+++ b/config/model/efficientformer/efficientformer-l1-detection.yaml
@@ -38,8 +38,13 @@ model:
       name: fpn
       params:
         num_outs: 4
-        start_level: 0
-        end_level: -1
+        upsample_interpolation: nearest
+        lateral_conv_type: conv
+        num_lateral_conv: 1
+        fpn_conv_type: separable_conv
+        num_fpn_conv: 2
+        norm_type: batch_norm
+        act_type: relu
         add_extra_convs: False
         relu_before_extra_convs: False
     head:

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -62,8 +62,13 @@ model:
       name: fpn
       params:
         num_outs: 4
-        start_level: 0
-        end_level: -1
+        upsample_interpolation: nearest
+        lateral_conv_type: conv
+        num_lateral_conv: 1
+        fpn_conv_type: separable_conv
+        num_fpn_conv: 2
+        norm_type: batch_norm
+        act_type: relu
         add_extra_convs: False
         relu_before_extra_convs: False
     head:

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -62,8 +62,13 @@ model:
       name: fpn
       params:
         num_outs: 4
-        start_level: 0
-        end_level: -1
+        upsample_interpolation: nearest
+        lateral_conv_type: conv
+        num_lateral_conv: 1
+        fpn_conv_type: separable_conv
+        num_fpn_conv: 2
+        norm_type: batch_norm
+        act_type: relu
         add_extra_convs: False
         relu_before_extra_convs: False
     head:

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -62,8 +62,13 @@ model:
       name: fpn
       params:
         num_outs: 4
-        start_level: 0
-        end_level: -1
+        upsample_interpolation: nearest
+        lateral_conv_type: conv
+        num_lateral_conv: 1
+        fpn_conv_type: separable_conv
+        num_fpn_conv: 2
+        norm_type: batch_norm
+        act_type: relu
         add_extra_convs: False
         relu_before_extra_convs: False
     head:

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -50,8 +50,13 @@ model:
       name: fpn
       params:
         num_outs: 4
-        start_level: 0
-        end_level: -1
+        upsample_interpolation: nearest
+        lateral_conv_type: conv
+        num_lateral_conv: 1
+        fpn_conv_type: separable_conv
+        num_fpn_conv: 2
+        norm_type: batch_norm
+        act_type: relu
         add_extra_convs: False
         relu_before_extra_convs: False
     head:

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -35,8 +35,13 @@ model:
       name: fpn
       params:
         num_outs: 4
-        start_level: 0
-        end_level: -1
+        upsample_interpolation: nearest
+        lateral_conv_type: conv
+        num_lateral_conv: 1
+        fpn_conv_type: separable_conv
+        num_fpn_conv: 2
+        norm_type: batch_norm
+        act_type: relu
         add_extra_convs: False
         relu_before_extra_convs: False
     head:

--- a/src/netspresso_trainer/models/necks/experimental/fpn.py
+++ b/src/netspresso_trainer/models/necks/experimental/fpn.py
@@ -31,7 +31,9 @@ class FPN(nn.Module):
         self.upsample_interpolation = params.upsample_interpolation
 
         self.lateral_conv_type = params.lateral_conv_type
+        self.num_lateral_conv = params.num_lateral_conv
         self.fpn_conv_type = params.fpn_conv_type
+        self.num_fpn_conv = params.num_fpn_conv
         self.norm_type = params.norm_type
         self.act_type = params.act_type
 
@@ -51,10 +53,17 @@ class FPN(nn.Module):
         lateral_convlayer = BLOCK_FROM_LITERAL[self.lateral_conv_type]
         fpn_convlayer = BLOCK_FROM_LITERAL[self.fpn_conv_type]
         for i in range(self.num_ins):
-            l_conv = lateral_convlayer(in_channels=self.in_channels[i], out_channels=self.out_channels,
-                                       kernel_size=1, stride=1, norm_type=self.norm_type, act_type=self.act_type)
-            fpn_conv = fpn_convlayer(in_channels=self.out_channels, out_channels=self.out_channels,
-                                     kernel_size=3, stride=1)
+            l_conv = []
+            for _ in range(self.num_lateral_conv):
+                l_conv += [lateral_convlayer(in_channels=self.in_channels[i], out_channels=self.out_channels,
+                                             kernel_size=1, stride=1, norm_type=self.norm_type, act_type=self.act_type)]
+            l_conv = nn.Sequential(*l_conv)
+
+            fpn_conv = []
+            for _ in range(self.num_fpn_conv):
+                fpn_conv += [fpn_convlayer(in_channels=self.out_channels, out_channels=self.out_channels,
+                                           kernel_size=3, stride=1)]
+            fpn_conv = nn.Sequential(*fpn_conv)
 
             self.lateral_convs.append(l_conv)
             self.fpn_convs.append(fpn_conv)

--- a/src/netspresso_trainer/models/necks/experimental/fpn.py
+++ b/src/netspresso_trainer/models/necks/experimental/fpn.py
@@ -1,3 +1,7 @@
+"""
+This code is modified version of mmdetection.
+https://github.com/open-mmlab/mmdetection/blob/main/mmdet/models/necks/fpn.py
+"""
 from typing import List, Dict, Type
 
 from omegaconf import DictConfig

--- a/src/netspresso_trainer/models/necks/experimental/fpn.py
+++ b/src/netspresso_trainer/models/necks/experimental/fpn.py
@@ -76,7 +76,8 @@ class FPN(nn.Module):
                     in_channels = self.in_channels[self.num_ins - 1]
                 else:
                     in_channels = self.out_channels
-                extra_fpn_conv = nn.Conv2d(in_channels, self.out_channels, kernel_size=3, stride=2, padding=1)
+                extra_fpn_conv = fpn_convlayer(in_channels=in_channels, out_channels=self.out_channels,
+                                               kernel_size=3, stride=2)
                 self.fpn_convs.append(extra_fpn_conv)
 
         self._intermediate_features_dim = [self.out_channels for _ in range(self.num_outs)]

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -121,6 +121,36 @@ class ConvLayer(nn.Module):
         return f"{self.block}"
 
 
+class SeparableConvLayer(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: Union[int, Tuple[int, int]],
+        stride: Optional[Union[int, Tuple[int, int]]] = 1,
+        dilation: Optional[Union[int, Tuple[int, int]]] = 1,
+        padding: Optional[Union[int, Tuple[int, int]]] = None,
+        bias: bool = False,
+        padding_mode: Optional[str] = 'zeros',
+        use_norm: bool = True,
+        norm_type: Optional[str] = None,
+        use_act: bool = True,
+        act_type: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.depthwise = ConvLayer(in_channels=in_channels, out_channels=in_channels,
+                                   kernel_size=kernel_size, stride=stride, dilation=dilation,
+                                   padding=padding, groups=in_channels, bias=bias, padding_mode=padding_mode,
+                                   use_norm=use_norm, norm_type=norm_type, use_act=use_act, act_type=act_type,)
+        self.pointwise = ConvLayer(in_channels=in_channels, out_channels=out_channels, kernel_size=1,
+                                   use_norm=use_norm, norm_type=norm_type, use_act=use_act, act_type=act_type,)
+
+    def forward(self, x: Union[Tensor, Proxy]) -> Union[Tensor, Proxy]:
+        x = self.depthwise(x)
+        x = self.pointwise(x)
+        return x
+
+
 @torch.fx.wrap
 def tensor_slice(tensor: Tensor, dim, index):
     return tensor.select(dim, index)


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

This PR is part of #376

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add `SeparableConvLayer`.
- Add various options to `FPN`
  - `upsample_interpolation`: Determines interpolation method for upsample
  - `lateral_conv_type`: Convolution type which is used for building laterals. One of 'conv' or 'separable_conv'
  - `num_lateral_conv`: The number of lateral_conv layers.
  - `fpn_conv_type`: Convolution type which is applied after top-down feature mixing.
  - `num_fpn_conv`: The number of fpn_conv layers.
  - `norm_type`: Batch normalization type of `FPN`.
  - `act_type`: Activation type of `FPN`.

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```