### PR TITLE
hotfix: handle best_epoch init error in TrainingSummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix best_epoch init error in TrainingSummary in case of training resume by `@illian01` in [PR 448](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/448)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/utils/record.py
+++ b/src/netspresso_trainer/utils/record.py
@@ -136,7 +136,7 @@ class TrainingSummary:
         self.last_epoch = list(self.train_losses.keys())[-1]
         try: # self.valid_losses is empty if validation is not performed
             self.best_epoch = min(self.valid_losses, key=self.valid_losses.get)
-        except:
+        except ValueError:
             self.best_epoch = self.last_epoch
 
 @dataclass

--- a/src/netspresso_trainer/utils/record.py
+++ b/src/netspresso_trainer/utils/record.py
@@ -133,9 +133,11 @@ class TrainingSummary:
     success: bool = False
 
     def __post_init__(self):
-        self.best_epoch = min(self.valid_losses, key=self.valid_losses.get)
         self.last_epoch = list(self.train_losses.keys())[-1]
-
+        try: # self.valid_losses is empty if validation is not performed
+            self.best_epoch = min(self.valid_losses, key=self.valid_losses.get)
+        except:
+            self.best_epoch = self.last_epoch
 
 @dataclass
 class EvaluationSummary:


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: N/A

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- `self.valid_losses` is empty when try to resume training
- set `self.best_epoch` as `self.last_epoch` when `self.valid_losses` is empty dict

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.