### PR TITLE
Temporarily add IoUMeter to fix segmentation metric logic bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Bug Fixes:
 
 - Fix best_epoch init error in TrainingSummary in case of training resume by `@illian01` in [PR 448](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/448)
+- Fix segmentation metric logic bug by `@illian01` in [PR 455](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/455)
 
 ## Breaking Changes:
 


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #454


We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Temporarily add `IoUMeter` class

TODO
- Existing `MetricMeter` is not fit with IoU computation logic. `MetricMeter` class should be more generalized.

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.