### PR TITLE
Add required post-processor and loss modules for YoloFastest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ docker-compose.yml
 
 !data/.gitkeep
 !weights/.gitkeep
+
+.DS_Store
+._.DS_Store
+**/.DS_Store
+**/._.DS_Store

--- a/config/model/yolo/yolo-fastest-detection.yaml
+++ b/config/model/yolo/yolo-fastest-detection.yaml
@@ -84,3 +84,4 @@ model:
         # cls_weight: 1.0
         # obj_weight: 1.0
         weight: 1.0
+        anchors: [[12,18, 37,49, 52,132], [115,73, 119,199, 242,238]]

--- a/docs/components/model/losses.md
+++ b/docs/components/model/losses.md
@@ -76,6 +76,25 @@ Loss module for [AnchorFreeDecoupledHead](../../models/heads/anchorfreedecoupled
   ```
 </details>
 
+### YOLOFastestLoss
+
+Loss module for [YoloFastestHead](../../models/heads/yolofastesthead.md). This loss follows the [YOLOFastest implementation](https://github.com/dog-qiuqiu/Yolo-Fastest).
+
+| Field <img width=200/> | Description |
+|---|---|
+| `criterion` | (str) Criterion must be "yolo_fastest_loss" to use `YOLOFastestLoss`. |
+| `weight` | (float) Weight for the YOLOFastest loss. |
+
+<details>
+  <summary>YOLOFastest loss example</summary>
+  ```yaml
+  model:
+    losses:
+      - criterion: yolo_fastest_loss
+        weight: ~
+  ```
+</details>
+
 ### RetinaNetLoss 
 
 Loss module for [AnchorDecoupledHead](../../models/heads/anchordecoupledhead.md). This loss follows torchvision implementation, it contains classification loss via focal loss and box regression loss via L1 loss.

--- a/docs/models/heads/yolofastesthead.md
+++ b/docs/models/heads/yolofastesthead.md
@@ -1,0 +1,1 @@
+# YOLOFastestHead

--- a/src/netspresso_trainer/losses/detection/__init__.py
+++ b/src/netspresso_trainer/losses/detection/__init__.py
@@ -1,2 +1,3 @@
 from .retinanet import RetinaNetLoss
 from .yolox import YOLOXLoss
+from .yolo_fastest import YOLOFastestLoss

--- a/src/netspresso_trainer/losses/detection/yolo_fastest.py
+++ b/src/netspresso_trainer/losses/detection/yolo_fastest.py
@@ -1,233 +1,287 @@
+# YOLOv5 🚀 by Ultralytics, AGPL-3.0 license
+"""
+Loss functions
+"""
+
+import math
+
 import torch
 import torch.nn as nn
 
-from typing import List, Dict
-from .yolox import xyxy2cxcywh
+
+def bbox_iou(box1, box2, xywh=True, GIoU=False, DIoU=False, CIoU=False, eps=1e-7):
+    # Returns Intersection over Union (IoU) of box1(1,4) to box2(n,4)
+
+    # Get the coordinates of bounding boxes
+    if xywh:  # transform from xywh to xyxy
+        (x1, y1, w1, h1), (x2, y2, w2, h2) = box1.chunk(4, -1), box2.chunk(4, -1)
+        w1_, h1_, w2_, h2_ = w1 / 2, h1 / 2, w2 / 2, h2 / 2
+        b1_x1, b1_x2, b1_y1, b1_y2 = x1 - w1_, x1 + w1_, y1 - h1_, y1 + h1_
+        b2_x1, b2_x2, b2_y1, b2_y2 = x2 - w2_, x2 + w2_, y2 - h2_, y2 + h2_
+    else:  # x1, y1, x2, y2 = box1
+        b1_x1, b1_y1, b1_x2, b1_y2 = box1.chunk(4, -1)
+        b2_x1, b2_y1, b2_x2, b2_y2 = box2.chunk(4, -1)
+        w1, h1 = b1_x2 - b1_x1, (b1_y2 - b1_y1).clamp(eps)
+        w2, h2 = b2_x2 - b2_x1, (b2_y2 - b2_y1).clamp(eps)
+
+    # Intersection area
+    inter = (b1_x2.minimum(b2_x2) - b1_x1.maximum(b2_x1)).clamp(0) * \
+            (b1_y2.minimum(b2_y2) - b1_y1.maximum(b2_y1)).clamp(0)
+
+    # Union Area
+    union = w1 * h1 + w2 * h2 - inter + eps
+
+    # IoU
+    iou = inter / union
+    if CIoU or DIoU or GIoU:
+        cw = b1_x2.maximum(b2_x2) - b1_x1.minimum(b2_x1)  # convex (smallest enclosing box) width
+        ch = b1_y2.maximum(b2_y2) - b1_y1.minimum(b2_y1)  # convex height
+        if CIoU or DIoU:  # Distance or Complete IoU https://arxiv.org/abs/1911.08287v1
+            c2 = cw ** 2 + ch ** 2 + eps  # convex diagonal squared
+            rho2 = ((b2_x1 + b2_x2 - b1_x1 - b1_x2) ** 2 + (b2_y1 + b2_y2 - b1_y1 - b1_y2) ** 2) / 4  # center dist ** 2
+            if CIoU:  # https://github.com/Zzh-tju/DIoU-SSD-pytorch/blob/master/utils/box/box_utils.py#L47
+                v = (4 / math.pi ** 2) * (torch.atan(w2 / h2) - torch.atan(w1 / h1)).pow(2)
+                with torch.no_grad():
+                    alpha = v / (v - iou + (1 + eps))
+                return iou - (rho2 / c2 + v * alpha)  # CIoU
+            return iou - rho2 / c2  # DIoU
+        c_area = cw * ch + eps  # convex area
+        return iou - (c_area - union) / c_area  # GIoU https://arxiv.org/pdf/1902.09630.pdf
+    return iou  # IoU
+
+def smooth_BCE(eps=0.1):  # https://github.com/ultralytics/yolov3/issues/238#issuecomment-598028441
+    # return positive, negative label smoothing BCE targets
+    return 1.0 - 0.5 * eps, 0.5 * eps
 
 
-def iou_width_height(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor:
-    """
-    Parameters:
-        boxes1 (tensor): width and height of the first bounding boxes
-        boxes2 (tensor): width and height of the second bounding boxes
-    Returns:
-        tensor: Intersection over union of the corresponding boxes
-    """
-    intersection = torch.min(boxes1[..., 0], boxes2[..., 0]) * torch.min(
-        boxes1[..., 1], boxes2[..., 1]
-    )
-    union = (
-        boxes1[..., 0] * boxes1[..., 1] + boxes2[..., 0] * boxes2[..., 1] - intersection
-    )
-    return intersection / union
+class BCEBlurWithLogitsLoss(nn.Module):
+    # BCEwithLogitLoss() with reduced missing label effects.
+    def __init__(self, alpha=0.05):
+        super().__init__()
+        self.loss_fcn = nn.BCEWithLogitsLoss(reduction='none')  # must be nn.BCEWithLogitsLoss()
+        self.alpha = alpha
+
+    def forward(self, pred, true):
+        loss = self.loss_fcn(pred, true)
+        pred = torch.sigmoid(pred)  # prob from logits
+        dx = pred - true  # reduce only missing label effects
+        # dx = (pred - true).abs()  # reduce missing label and false label effects
+        alpha_factor = 1 - torch.exp((dx - 1) / (self.alpha + 1e-4))
+        loss *= alpha_factor
+        return loss.mean()
 
 
-def intersection_over_union(boxes_preds, boxes_labels, box_format="midpoint"):
-    """
-    Video explanation of this function:
-    https://youtu.be/XXYG5ZWtjj0
+class FocalLoss(nn.Module):
+    # Wraps focal loss around existing loss_fcn(), i.e. criteria = FocalLoss(nn.BCEWithLogitsLoss(), gamma=1.5)
+    def __init__(self, loss_fcn, gamma=1.5, alpha=0.25):
+        super().__init__()
+        self.loss_fcn = loss_fcn  # must be nn.BCEWithLogitsLoss()
+        self.gamma = gamma
+        self.alpha = alpha
+        self.reduction = loss_fcn.reduction
+        self.loss_fcn.reduction = 'none'  # required to apply FL to each element
 
-    This function calculates intersection over union (iou) given pred boxes
-    and target boxes.
+    def forward(self, pred, true):
+        loss = self.loss_fcn(pred, true)
+        # p_t = torch.exp(-loss)
+        # loss *= self.alpha * (1.000001 - p_t) ** self.gamma  # non-zero power for gradient stability
 
-    Parameters:
-        boxes_preds (tensor): Predictions of Bounding Boxes (BATCH_SIZE, 4)
-        boxes_labels (tensor): Correct labels of Bounding Boxes (BATCH_SIZE, 4)
-        box_format (str): midpoint/corners, if boxes (x,y,w,h) or (x1,y1,x2,y2)
+        # TF implementation https://github.com/tensorflow/addons/blob/v0.7.1/tensorflow_addons/losses/focal_loss.py
+        pred_prob = torch.sigmoid(pred)  # prob from logits
+        p_t = true * pred_prob + (1 - true) * (1 - pred_prob)
+        alpha_factor = true * self.alpha + (1 - true) * (1 - self.alpha)
+        modulating_factor = (1.0 - p_t) ** self.gamma
+        loss *= alpha_factor * modulating_factor
 
-    Returns:
-        tensor: Intersection over union for all examples
-    """
+        if self.reduction == 'mean':
+            return loss.mean()
+        elif self.reduction == 'sum':
+            return loss.sum()
+        else:  # 'none'
+            return loss
 
-    if box_format == "midpoint":
-        box1_x1 = boxes_preds[..., 0:1] - boxes_preds[..., 2:3] / 2
-        box1_y1 = boxes_preds[..., 1:2] - boxes_preds[..., 3:4] / 2
-        box1_x2 = boxes_preds[..., 0:1] + boxes_preds[..., 2:3] / 2
-        box1_y2 = boxes_preds[..., 1:2] + boxes_preds[..., 3:4] / 2
-        box2_x1 = boxes_labels[..., 0:1] - boxes_labels[..., 2:3] / 2
-        box2_y1 = boxes_labels[..., 1:2] - boxes_labels[..., 3:4] / 2
-        box2_x2 = boxes_labels[..., 0:1] + boxes_labels[..., 2:3] / 2
-        box2_y2 = boxes_labels[..., 1:2] + boxes_labels[..., 3:4] / 2
 
-    if box_format == "corners":
-        box1_x1 = boxes_preds[..., 0:1]
-        box1_y1 = boxes_preds[..., 1:2]
-        box1_x2 = boxes_preds[..., 2:3]
-        box1_y2 = boxes_preds[..., 3:4]
-        box2_x1 = boxes_labels[..., 0:1]
-        box2_y1 = boxes_labels[..., 1:2]
-        box2_x2 = boxes_labels[..., 2:3]
-        box2_y2 = boxes_labels[..., 3:4]
+class QFocalLoss(nn.Module):
+    # Wraps Quality focal loss around existing loss_fcn(), i.e. criteria = FocalLoss(nn.BCEWithLogitsLoss(), gamma=1.5)
+    def __init__(self, loss_fcn, gamma=1.5, alpha=0.25):
+        super().__init__()
+        self.loss_fcn = loss_fcn  # must be nn.BCEWithLogitsLoss()
+        self.gamma = gamma
+        self.alpha = alpha
+        self.reduction = loss_fcn.reduction
+        self.loss_fcn.reduction = 'none'  # required to apply FL to each element
 
-    x1 = torch.max(box1_x1, box2_x1)
-    y1 = torch.max(box1_y1, box2_y1)
-    x2 = torch.min(box1_x2, box2_x2)
-    y2 = torch.min(box1_y2, box2_y2)
+    def forward(self, pred, true):
+        loss = self.loss_fcn(pred, true)
 
-    intersection = (x2 - x1).clamp(0) * (y2 - y1).clamp(0)
-    box1_area = abs((box1_x2 - box1_x1) * (box1_y2 - box1_y1))
-    box2_area = abs((box2_x2 - box2_x1) * (box2_y2 - box2_y1))
+        pred_prob = torch.sigmoid(pred)  # prob from logits
+        alpha_factor = true * self.alpha + (1 - true) * (1 - self.alpha)
+        modulating_factor = torch.abs(true - pred_prob) ** self.gamma
+        loss *= alpha_factor * modulating_factor
 
-    return intersection / (box1_area + box2_area - intersection + 1e-6)
+        if self.reduction == 'mean':
+            return loss.mean()
+        elif self.reduction == 'sum':
+            return loss.sum()
+        else:  # 'none'
+            return loss
 
 
 class YOLOFastestLoss(nn.Module):
-    def __init__(self, cur_epoch=None, anchors=None, **kwargs) -> None:
-        super(YOLOFastestLoss, self).__init__()
-        self.bce = nn.BCEWithLogitsLoss()
-        self.mse = nn.MSELoss()
-        self.entropy = nn.CrossEntropyLoss()
-        self.sigmoid = nn.Sigmoid()
-        self.lambda_coord = 1
-        self.lambda_noobj = 1
+    sort_obj_iou = False
+
+    # Compute losses
+    def __init__(self, cur_epoch=None, anchors=None, **kwargs):
+        super().__init__()
+        # Define criteria
+        BCEcls = nn.BCEWithLogitsLoss()
+        BCEobj = nn.BCEWithLogitsLoss()
+
+        # Class label smoothing https://arxiv.org/pdf/1902.04103.pdf eqn 3
+        self.cp, self.cn = smooth_BCE()  # positive, negative BCE targets
+
+        # Focal loss
+        g = 0.5  # focal loss gamma
+        if g > 0:
+            BCEcls, BCEobj = FocalLoss(BCEcls, g), FocalLoss(BCEobj, g)
+
+
+        # self.balance = {3: [4.0, 1.0, 0.4]}.get(m.nl, [4.0, 1.0, 0.25, 0.06, 0.02])  # P3-P7
+        self.ssi = 0  # stride 16 index
+        self.BCEcls, self.BCEobj, self.gr = BCEcls, BCEobj, 1.0
+        self.na = len(anchors[0]) // 2  # number of anchors
+        self.nl = len(anchors)  # number of layers
         self.anchors = anchors
-        self.num_layers = len(anchors)
-        self.num_anchors = len(anchors[0]) // 2
-        self.ignore_iou_threshold = 0.5
+        self.anchor_t = 4.0
 
-    def forward(self, preds: List, target: Dict) -> torch.Tensor:
-        total_loss = torch.zeros(1, device=preds[0].device)
-        img_size = target["img_size"]
-        gt = target["gt"]
-        self.grids = [torch.zeros(1)] * len(preds)  # 각 layer 별로 grid를 생성함.
-        self.num_classes = target["num_classes"]
-        out_for_loss = self.get_out_for_loss(preds, img_size)
+    def forward(self, p, targets):  # predictions, targets
+        p = p['pred']
+        self.nc = targets['num_classes']
+        lcls = torch.zeros(1, device=p[0].device)  # class loss
+        lbox = torch.zeros(1, device=p[0].device)  # box loss
+        lobj = torch.zeros(1, device=p[0].device)  # object loss
+        tcls, tbox, indices, anchors = self.build_targets(p, targets)  # targets
 
-        num_channels = [o.shape[-1] for o in preds]
-        objs1 = []
-        objs2 = []
-        for idx in range(len(gt)):
-            gt[idx]["boxes"] = xyxy2cxcywh(gt[idx]["boxes"])
-            obj1, obj2 = self.get_objectness_indicators(
-                gt[idx]["boxes"],
-                gt[idx]["labels"],
-                self.anchors,
-                num_channels,
-                img_size,
-            )
-            objs1.append(obj1)
-            objs2.append(obj2)
-        objs1 = torch.stack(objs1, dim=0)
-        objs2 = torch.stack(objs2, dim=0)
-        objs = [objs1, objs2]
 
-        for idx, obj in enumerate(objs):
-            total_loss += self.get_losses(out_for_loss[idx], obj, num_channels[idx])
+        # Losses
+        for i, pi in enumerate(p):  # layer index, layer predictions
+            b, a, gj, gi = indices[i]  # image, anchor, gridy, gridx
+            tobj = torch.zeros(pi.shape[:4], dtype=pi.dtype, device=pi.device)  # target obj
 
-        return total_loss
+            n = b.shape[0]  # number of targets
+            if n:
+                pxy, pwh, _, pcls = pi[b, a, gj, gi].split((2, 2, 1, self.nc), 1)  # target-subset of predictions
 
-    def get_objectness_indicators(
-        self, bboxes, labels, anchors, num_channels, img_size
-    ):
-        targets = [torch.zeros((self.num_anchors, nc, nc, 6)) for nc in num_channels]
-        anchors = [
-            [tuple(anchor[i : i + 2]) for i in range(0, len(anchor), 2)]
-            for anchor in anchors
-        ]
-        anchors = torch.tensor(anchors[0] + anchors[1])
-        for box, class_label in zip(bboxes, labels):
-            iou_anchors = iou_width_height(box[2:4], anchors)
-            anchor_indices = iou_anchors.argsort(descending=True, dim=0)
-            x, y, width, height = box
-            has_anchor = [False] * 2
+                # Regression
+                pxy = pxy.sigmoid()
+                pwh = pwh * torch.log(1e-16 + anchors[i])
+                pbox = torch.cat((pxy, pwh), 1)  # predicted box
+                iou = bbox_iou(pbox, tbox[i], CIoU=True).squeeze()  # iou(prediction, target)
+                lbox += (1.0 - iou).mean()  # iou loss
 
-        for anchor_idx in anchor_indices:
-            scale_idx = anchor_idx // self.num_anchors
-            anchor_on_scale = anchor_idx % self.num_anchors
-            S = num_channels[scale_idx]
-            # i and j are denoted by the offset of the corresponding cell
-            i, j = int(S * y / img_size), int(S * x / img_size)
+                # Objectness
+                iou = iou.detach().clamp(0).type(tobj.dtype)
+                if self.sort_obj_iou:
+                    j = iou.argsort()
+                    b, a, gj, gi, iou = b[j], a[j], gj[j], gi[j], iou[j]
+                if self.gr < 1:
+                    iou = (1.0 - self.gr) + self.gr * iou
+                tobj[b, a, gj, gi] = iou  # iou ratio
 
-            anchor_taken = targets[scale_idx][anchor_on_scale, i, j, 0]
+                # Classification
+                if self.nc > 1:  # cls loss (only if multiple classes)
+                    t = torch.full_like(pcls, self.cn, device=pcls.device)  # targets
+                    t[range(n), tcls[i]] = self.cp
+                    lcls += self.BCEcls(pcls, t)  # BCE
 
-            if not anchor_taken and not has_anchor[scale_idx]:
-                targets[scale_idx][anchor_on_scale, i, j, 0] = 1
-                x_cell, y_cell = (
-                    S * x / img_size - j,
-                    S * y / img_size - i,
-                )  # both between [0,1]
-                width_cell, height_cell = (
-                    S * width / img_size,
-                    S * height / img_size,
-                )  # can be greater than 1 since it's relative to cell
-                box_coordinates = torch.tensor(
-                    [x_cell, y_cell, width_cell, height_cell]
-                )
+                # Append targets to text file
+                # with open('targets.txt', 'a') as file:
+                #     [file.write('%11.5g ' * 4 % tuple(x) + '\n') for x in torch.cat((txy[i], twh[i]), 1)]
 
-                targets[scale_idx][anchor_on_scale, i, j, 1:5] = box_coordinates
-                targets[scale_idx][anchor_on_scale, i, j, 5] = int(class_label)
-                has_anchor[scale_idx] = True
-            elif (
-                not anchor_taken and iou_anchors[anchor_idx] > self.ignore_iou_threshold
-            ):
-                targets[scale_idx][anchor_on_scale, i, j, 0] = 0  # ignore prediction
+            obji = self.BCEobj(pi[..., 4], tobj)
+            lobj += obji  # obj loss
+        #     if self.autobalance:
+        #         self.balance[i] = self.balance[i] * 0.9999 + 0.0001 / obji.detach().item()
 
-        return targets
+        # if self.autobalance:
+        #     self.balance = [x / self.balance[self.ssi] for x in self.balance]
+        # lbox *= self.hyp['box']
+        # lobj *= self.hyp['obj']
+        # lcls *= self.hyp['cls']
+        bs = tobj.shape[0]  # batch size
 
-    def get_losses(self, preds, objs, num_channel):
-        pred = preds.view(
-            -1, self.num_anchors, num_channel, num_channel, 5 + self.num_classes
-        )
-        target = objs.view(-1, self.num_anchors, num_channel, num_channel, 6)
-        obj = target[..., 0] == 1
-        noobj = target[..., 0] == 0
+        return (lbox + lobj + lcls) * bs
 
-        no_object_loss = self.bce(
-            pred[..., 4:5][noobj],
-            target[..., 0:1][noobj],
-        )
+    def build_targets(self, p, targets):
+        # Build targets for compute_loss(), input targets(image,class,x,y,w,h)
+        targets = targets['gt']
+        max([len(t['labels']) for t in targets])
+        labels = []
+        for batch_idx, t in enumerate(targets):
+            batch_boxes = t['boxes'].view(-1, 4)
+            batch_labels = t['labels'].view(-1, 1)
 
-        box_preds = pred[..., :4]
-        ious = intersection_over_union(box_preds[obj], target[..., 1:5][obj]).detach()
+            index = torch.tensor(batch_idx, device=batch_boxes.device).expand(len(batch_labels)).view(len(batch_labels), 1)
+            target = torch.cat([index, batch_labels, batch_boxes], dim=-1)
+            labels.append(target)
 
-        object_loss = self.mse(
-            self.sigmoid(pred[..., 4:5][obj]), ious * target[..., 0:1][obj]
-        )
-        target[..., 3:5] = torch.log(1e-16 + target[..., 3:5])
-        box_loss = self.mse(pred[..., 1:5][obj], target[..., 1:5][obj])
-        class_loss = self.entropy(pred[..., 5:][obj], target[..., 5][obj].long())
-        return (
-            self.lambda_noobj * no_object_loss
-            + self.lambda_coord * box_loss
-            + class_loss
-            + object_loss
-        )
 
-    def get_output(self, output, k, img_size, dtype):
-        grid = self.grids[k]
-        num_anchors = self.num_anchors
-        anchors = torch.tensor(self.anchors[k]).to(output.device)
-        anchors = anchors.view(1, num_anchors, 1, 2)
-        batch_size = output.shape[0]
-        n_ch = 5 + self.num_classes
-        hsize, wsize = output.shape[-2:]
-        if grid.shape[2:4] != output.shape[2:4]:
-            yv, xv = torch.meshgrid(
-                torch.arange(hsize), torch.arange(wsize), indexing="ij"
-            )
-            grid = torch.stack((xv, yv), 2).view(1, 1, hsize, wsize, 2).type(dtype)
-            self.grids[k] = grid
-        output = output.view(
-            batch_size, self.num_anchors, n_ch, hsize, wsize
-        )  # [8, 3, 85, h, w]
-        output = output.permute(0, 1, 3, 4, 2).reshape(
-            batch_size, -1, hsize * wsize, n_ch
-        )
-        grid = grid.view(1, 1, -1, 2)
-        output = torch.cat(
+        targets = torch.cat(labels, dim=0)
+        na, nt = self.na, targets.shape[0]  # number of anchors, targets
+        tcls, tbox, indices, anch = [], [], [], []
+        gain = torch.ones(7, device=p[0].device)  # normalized to gridspace gain
+        ai = torch.arange(na, device=p[0].device).float().view(na, 1).repeat(1, nt)  # same as .repeat_interleave(nt)
+        targets = torch.cat((targets.repeat(na, 1, 1), ai[..., None]), 2)  # append anchor indices
+
+        g = 0.5  # bias
+        off = torch.tensor(
             [
-                torch.sigmoid(output[..., :2]) + grid,  # cx and cy
-                # box_width and box_height
-                output[..., 2:4] + torch.log(1e-16 + anchors / img_size),
-                output[..., 4:5],  # confidence score
-                output[..., 5:],  # cls prob
+                [0, 0],
+                [1, 0],
+                [0, 1],
+                [-1, 0],
+                [0, -1],  # j,k,l,m
+                # [1, 1], [1, -1], [-1, 1], [-1, -1],  # jk,jm,lk,lm
             ],
-            dim=-1,
-        )
-        return output
+            device=p[0].device).float() * g  # offsets
 
-    def get_out_for_loss(self, preds, img_size):
-        out_for_loss = list()
-        for k, o in enumerate(preds):
-            out_for_loss.append(self.get_output(o, k, img_size, o.type()))
-        return out_for_loss
+        for i in range(self.nl):
+            p[i] = p[i].view(p[i].shape[0], self.na, 5+self.nc, p[i].shape[2], -1).permute(0, 1, 3, 4, 2)
+            anchors, shape = torch.tensor(self.anchors[i], device=p[i].device), p[i].shape
+            gain[2:6] = torch.tensor(shape)[[3, 2, 3, 2]]  # xyxy gain
+
+            # Match targets to anchors
+            t = targets * gain  # shape(3,n,7)
+            if nt:
+                # Matches
+                anchors = anchors.view(-1, self.nl)
+                r = t[..., 4:6] / anchors[:, None]  # wh ratio
+                j = torch.max(r, 1 / r).max(2)[0] < self.anchor_t  # compare
+                # j = wh_iou(anchors, t[:, 4:6]) > model.hyp['iou_t']  # iou(3,n)=wh_iou(anchors(3,2), gwh(n,2))
+                t = t[j]  # filter
+
+                # Offsets
+                gxy = t[:, 2:4]  # grid xy
+                gxi = gain[[2, 3]] - gxy  # inverse
+                j, k = ((gxy % 1 < g) & (gxy > 1)).T
+                l, m = ((gxi % 1 < g) & (gxi > 1)).T
+                j = torch.stack((torch.ones_like(j), j, k, l, m))
+                t = t.repeat((5, 1, 1))[j]
+                offsets = (torch.zeros_like(gxy)[None] + off[:, None])[j]
+            else:
+                t = targets[0]
+                offsets = 0
+
+            # Define
+            bc, gxy, gwh, a = t.chunk(4, 1)  # (image, class), grid xy, grid wh, anchors
+            a, (b, c) = a.long().view(-1), bc.long().T  # anchors, image, class
+            gij = (gxy - offsets).long()
+            gi, gj = gij.T  # grid indices
+
+            # Append
+            indices.append((b, a, gj.clamp_(0, shape[2] - 1), gi.clamp_(0, shape[3] - 1)))  # image, anchor, grid
+            tbox.append(torch.cat((gxy - gij, torch.log(1e-16 + gwh)), 1))  # box
+            anch.append(anchors[a])  # anchors
+            tcls.append(c)  # class
+
+        return tcls, tbox, indices, anch

--- a/src/netspresso_trainer/losses/detection/yolo_fastest.py
+++ b/src/netspresso_trainer/losses/detection/yolo_fastest.py
@@ -1,10 +1,8 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-import numpy as np
 
 from typing import List, Dict
-from .yolox import bboxes_iou, xyxy2cxcywh
+from .yolox import xyxy2cxcywh
 
 
 def iou_width_height(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor:
@@ -15,8 +13,10 @@ def iou_width_height(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor
     Returns:
         tensor: Intersection over union of the corresponding boxes
     """
-    intersection = torch.min(boxes1[..., 0], boxes2[..., 0]) * torch.min(boxes1[..., 1], boxes2[..., 1])
-    union = (boxes1[..., 0] * boxes1[..., 1] + boxes2[..., 0] * boxes2[..., 1] - intersection)
+    intersection = torch.min(
+        boxes1[..., 0], boxes2[..., 0]) * torch.min(boxes1[..., 1], boxes2[..., 1])
+    union = (boxes1[..., 0] * boxes1[..., 1] +
+             boxes2[..., 0] * boxes2[..., 1] - intersection)
     return intersection / union
 
 
@@ -68,6 +68,7 @@ def intersection_over_union(boxes_preds, boxes_labels, box_format="midpoint"):
 
     return intersection / (box1_area + box2_area - intersection + 1e-6)
 
+
 class YOLOFastestLoss(nn.Module):
     def __init__(self, cur_epoch=None, anchors=None, **kwargs) -> None:
         super(YOLOFastestLoss, self).__init__()
@@ -75,8 +76,8 @@ class YOLOFastestLoss(nn.Module):
         self.mse = nn.MSELoss()
         self.entropy = nn.CrossEntropyLoss()
         self.sigmoid = nn.Sigmoid()
-        self.lambda_coord = 5
-        self.lambda_noobj = 0.5
+        self.lambda_coord = 1
+        self.lambda_noobj = 1
         self.anchors = anchors
         self.num_layers = len(anchors)
         self.num_anchors = len(anchors[0]) // 2
@@ -86,16 +87,17 @@ class YOLOFastestLoss(nn.Module):
         total_loss = torch.zeros(1, device=preds[0].device)
         img_size = target['img_size']
         gt = target['gt']
-        self.grids = [torch.zeros(1)] * len(preds) # 각 layer 별로 grid를 생성함.
+        self.grids = [torch.zeros(1)] * len(preds)  # 각 layer 별로 grid를 생성함.
         self.num_classes = target['num_classes']
-        x_shifts, y_shifts, expanded_strides, out_for_loss = self.get_offsets_and_out(preds, img_size)
+        out_for_loss = self.get_out_for_loss(preds, img_size)
 
         num_channels = [o.shape[-1] for o in preds]
         objs1 = []
         objs2 = []
         for idx in range(len(gt)):
             gt[idx]['boxes'] = xyxy2cxcywh(gt[idx]['boxes'])
-            obj1, obj2 = self.get_objectness_indicators(gt[idx]['boxes'], gt[idx]['labels'], self.anchors, num_channels, img_size)
+            obj1, obj2 = self.get_objectness_indicators(
+                gt[idx]['boxes'], gt[idx]['labels'], self.anchors, num_channels, img_size)
             objs1.append(obj1)
             objs2.append(obj2)
         objs1 = torch.stack(objs1, dim=0)
@@ -103,13 +105,16 @@ class YOLOFastestLoss(nn.Module):
         objs = [objs1, objs2]
 
         for idx, obj in enumerate(objs):
-           total_loss += self.get_losses(out_for_loss[idx], obj, num_channels[idx])
-        
+            total_loss += self.get_losses(
+                out_for_loss[idx], obj, num_channels[idx])
+
         return total_loss
 
     def get_objectness_indicators(self, bboxes, labels, anchors, num_channels, img_size):
-        targets = [torch.zeros((self.num_anchors, nc, nc, 6)) for nc in num_channels]
-        anchors = [[tuple(anchor[i : i + 2]) for i in range(0, len(anchor), 2)] for anchor in anchors]
+        targets = [torch.zeros((self.num_anchors, nc, nc, 6))
+                   for nc in num_channels]
+        anchors = [[tuple(anchor[i: i + 2])
+                    for i in range(0, len(anchor), 2)] for anchor in anchors]
         anchors = torch.tensor(anchors[0] + anchors[1])
         for box, class_label in zip(bboxes, labels):
             iou_anchors = iou_width_height(box[2:4], anchors)
@@ -121,26 +126,33 @@ class YOLOFastestLoss(nn.Module):
             scale_idx = anchor_idx // self.num_anchors
             anchor_on_scale = anchor_idx % self.num_anchors
             S = num_channels[scale_idx]
-            i, j = int(S * y/img_size), int(S * x/img_size) # which cell
+            # i and j are denoted by the offset of the corresponding cell
+            i, j = int(S * y/img_size), int(S * x/img_size)
 
             anchor_taken = targets[scale_idx][anchor_on_scale, i, j, 0]
 
             if not anchor_taken and not has_anchor[scale_idx]:
                 targets[scale_idx][anchor_on_scale, i, j, 0] = 1
-                x_cell, y_cell = S * x - j, S * y - i # both between [0,1]
-                width_cell, height_cell = (width, height,) # can be greater than 1 since it's relative to cell
-                box_coordinates = torch.tensor([x_cell, y_cell, width_cell, height_cell])
-                targets[scale_idx][anchor_on_scale, i, j, 1:5] = box_coordinates
+                x_cell, y_cell = S * x/img_size - j, S * \
+                    y/img_size - i  # both between [0,1]
+                width_cell, height_cell = (
+                    S * width/img_size, S * height/img_size,)  # can be greater than 1 since it's relative to cell
+                box_coordinates = torch.tensor(
+                    [x_cell, y_cell, width_cell, height_cell])
+
+                targets[scale_idx][anchor_on_scale,
+                                   i, j, 1:5] = box_coordinates
                 targets[scale_idx][anchor_on_scale, i, j, 5] = int(class_label)
                 has_anchor[scale_idx] = True
             elif not anchor_taken and iou_anchors[anchor_idx] > self.ignore_iou_threshold:
-                targets[scale_idx][anchor_on_scale, i, j, 0] = 0 # ignore prediction
+                targets[scale_idx][anchor_on_scale,
+                                   i, j, 0] = 0  # ignore prediction
 
         return targets
 
-
     def get_losses(self, preds, objs, num_channel):
-        pred = preds.view(-1, self.num_anchors, num_channel, num_channel, 5+self.num_classes)
+        pred = preds.view(-1, self.num_anchors, num_channel,
+                          num_channel, 5+self.num_classes)
         target = objs.view(-1, self.num_anchors, num_channel, num_channel, 6)
         obj = target[..., 0] == 1
         noobj = target[..., 0] == 0
@@ -150,18 +162,19 @@ class YOLOFastestLoss(nn.Module):
         )
 
         box_preds = pred[..., :4]
-        ious = intersection_over_union(box_preds[obj], target[..., 1:5][obj]).detach()
+        ious = intersection_over_union(
+            box_preds[obj], target[..., 1:5][obj]).detach()
 
-        object_loss = self.mse(self.sigmoid(pred[..., 4:5][obj]), ious * target[..., 0:1][obj])
+        object_loss = self.mse(self.sigmoid(
+            pred[..., 4:5][obj]), ious * target[..., 0:1][obj])
+        target[..., 3:5] = torch.log(1e-16 + target[..., 3:5])
         box_loss = self.mse(pred[..., 1:5][obj], target[..., 1:5][obj])
         class_loss = self.entropy(
             pred[..., 5:][obj], target[..., 5][obj].long()
         )
-
         return self.lambda_noobj * no_object_loss + self.lambda_coord * box_loss + class_loss + object_loss
 
-
-    def get_output_and_grid(self, output, k, stride, dtype):
+    def get_output(self, output, k, img_size, dtype):
         grid = self.grids[k]
         num_anchors = self.num_anchors
         anchors = torch.tensor(self.anchors[k]).to(output.device)
@@ -170,34 +183,27 @@ class YOLOFastestLoss(nn.Module):
         n_ch = 5 + self.num_classes
         hsize, wsize = output.shape[-2:]
         if grid.shape[2:4] != output.shape[2:4]:
-            yv, xv = torch.meshgrid(torch.arange(hsize), torch.arange(wsize), indexing="ij")
-            grid = torch.stack((xv, yv), 2).view(1, 1, hsize, wsize, 2).type(dtype)
+            yv, xv = torch.meshgrid(torch.arange(
+                hsize), torch.arange(wsize), indexing="ij")
+            grid = torch.stack((xv, yv), 2).view(
+                1, 1, hsize, wsize, 2).type(dtype)
             self.grids[k] = grid
-        output = output.view(batch_size, self.num_anchors, n_ch, hsize, wsize) # [8, 3, 85, h, w]
-        output = output.permute(0, 1, 3, 4, 2).reshape(batch_size, -1, hsize * wsize, n_ch)
+        output = output.view(batch_size, self.num_anchors,
+                             n_ch, hsize, wsize)  # [8, 3, 85, h, w]
+        output = output.permute(0, 1, 3, 4, 2).reshape(
+            batch_size, -1, hsize * wsize, n_ch)
         grid = grid.view(1, 1, -1, 2)
         output = torch.cat([
-                            torch.sigmoid(output[..., :2]) + grid, # cx and cy
-                            torch.exp(output[..., 2:4]) * anchors, # box_width and box_height
-                            output[..., 4:5], # confidence score: sigmoid를 사용하지 않는 이유는 BCE with logit loss를 사용하기 때문이다.
-                            output[..., 5:] # cls prob
-                            ], dim=-1)
-        return output, grid
+            torch.sigmoid(output[..., :2]) + grid,  # cx and cy
+            # box_width and box_height
+            output[..., 2:4] + torch.log(1e-16 + anchors/img_size),
+            output[..., 4:5],  # confidence score
+            output[..., 5:]  # cls prob
+        ], dim=-1)
+        return output
 
-
-    def get_offsets_and_out(self, preds, img_size):
-        x_shifts = list()
-        y_shifts = list()
+    def get_out_for_loss(self, preds, img_size):
         out_for_loss = list()
-        expanded_strides = list()
         for k, o in enumerate(preds):
-            stride_this_level = img_size // o.size(-1)
-            o, grid = self.get_output_and_grid(o, k, stride_this_level, o.type())
-            x_shifts.append(grid[:, :, 0])
-            y_shifts.append(grid[:, :, 1])
-            expanded_strides.append(
-                            torch.zeros(1, grid.shape[1]).fill_(stride_this_level).type_as(o))
-            out_for_loss.append(o)
-        # out_for_loss: [2, B, na, c*c, 85]
-
-        return x_shifts, y_shifts, expanded_strides, out_for_loss
+            out_for_loss.append(self.get_output(o, k, img_size, o.type()))
+        return out_for_loss

--- a/src/netspresso_trainer/losses/detection/yolo_fastest.py
+++ b/src/netspresso_trainer/losses/detection/yolo_fastest.py
@@ -1,15 +1,203 @@
-import torch 
+import torch
 import torch.nn as nn
-from typing import List, Dict  
+import torch.nn.functional as F
+import numpy as np
 
+from typing import List, Dict
+from .yolox import bboxes_iou, xyxy2cxcywh
+
+
+def iou_width_height(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor:
+    """ 
+    Parameters:
+        boxes1 (tensor): width and height of the first bounding boxes
+        boxes2 (tensor): width and height of the second bounding boxes
+    Returns:
+        tensor: Intersection over union of the corresponding boxes
+    """
+    intersection = torch.min(boxes1[..., 0], boxes2[..., 0]) * torch.min(boxes1[..., 1], boxes2[..., 1])
+    union = (boxes1[..., 0] * boxes1[..., 1] + boxes2[..., 0] * boxes2[..., 1] - intersection)
+    return intersection / union
+
+
+def intersection_over_union(boxes_preds, boxes_labels, box_format="midpoint"):
+    """
+    Video explanation of this function:
+    https://youtu.be/XXYG5ZWtjj0
+
+    This function calculates intersection over union (iou) given pred boxes
+    and target boxes.
+
+    Parameters:
+        boxes_preds (tensor): Predictions of Bounding Boxes (BATCH_SIZE, 4)
+        boxes_labels (tensor): Correct labels of Bounding Boxes (BATCH_SIZE, 4)
+        box_format (str): midpoint/corners, if boxes (x,y,w,h) or (x1,y1,x2,y2)
+
+    Returns:
+        tensor: Intersection over union for all examples
+    """
+
+    if box_format == "midpoint":
+        box1_x1 = boxes_preds[..., 0:1] - boxes_preds[..., 2:3] / 2
+        box1_y1 = boxes_preds[..., 1:2] - boxes_preds[..., 3:4] / 2
+        box1_x2 = boxes_preds[..., 0:1] + boxes_preds[..., 2:3] / 2
+        box1_y2 = boxes_preds[..., 1:2] + boxes_preds[..., 3:4] / 2
+        box2_x1 = boxes_labels[..., 0:1] - boxes_labels[..., 2:3] / 2
+        box2_y1 = boxes_labels[..., 1:2] - boxes_labels[..., 3:4] / 2
+        box2_x2 = boxes_labels[..., 0:1] + boxes_labels[..., 2:3] / 2
+        box2_y2 = boxes_labels[..., 1:2] + boxes_labels[..., 3:4] / 2
+
+    if box_format == "corners":
+        box1_x1 = boxes_preds[..., 0:1]
+        box1_y1 = boxes_preds[..., 1:2]
+        box1_x2 = boxes_preds[..., 2:3]
+        box1_y2 = boxes_preds[..., 3:4]
+        box2_x1 = boxes_labels[..., 0:1]
+        box2_y1 = boxes_labels[..., 1:2]
+        box2_x2 = boxes_labels[..., 2:3]
+        box2_y2 = boxes_labels[..., 3:4]
+
+    x1 = torch.max(box1_x1, box2_x1)
+    y1 = torch.max(box1_y1, box2_y1)
+    x2 = torch.min(box1_x2, box2_x2)
+    y2 = torch.min(box1_y2, box2_y2)
+
+    intersection = (x2 - x1).clamp(0) * (y2 - y1).clamp(0)
+    box1_area = abs((box1_x2 - box1_x1) * (box1_y2 - box1_y1))
+    box2_area = abs((box2_x2 - box2_x1) * (box2_y2 - box2_y1))
+
+    return intersection / (box1_area + box2_area - intersection + 1e-6)
 
 class YOLOFastestLoss(nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, cur_epoch=None, anchors=None, **kwargs) -> None:
         super(YOLOFastestLoss, self).__init__()
-    
-    def forward(self, out: List, target: Dict) -> torch.Tensor:
-        pass 
+        self.bce = nn.BCEWithLogitsLoss()
+        self.mse = nn.MSELoss()
+        self.entropy = nn.CrossEntropyLoss()
+        self.sigmoid = nn.Sigmoid()
+        self.lambda_coord = 5
+        self.lambda_noobj = 0.5
+        self.anchors = anchors
+        self.num_layers = len(anchors)
+        self.num_anchors = len(anchors[0]) // 2
+        self.ignore_iou_threshold = 0.5
+
+    def forward(self, preds: List, target: Dict) -> torch.Tensor:
+        total_loss = torch.zeros(1, device=preds[0].device)
+        img_size = target['img_size']
+        gt = target['gt']
+        self.grids = [torch.zeros(1)] * len(preds) # 각 layer 별로 grid를 생성함.
+        self.num_classes = target['num_classes']
+        x_shifts, y_shifts, expanded_strides, out_for_loss = self.get_offsets_and_out(preds, img_size)
+
+        num_channels = [o.shape[-1] for o in preds]
+        objs1 = []
+        objs2 = []
+        for idx in range(len(gt)):
+            gt[idx]['boxes'] = xyxy2cxcywh(gt[idx]['boxes'])
+            obj1, obj2 = self.get_objectness_indicators(gt[idx]['boxes'], gt[idx]['labels'], self.anchors, num_channels, img_size)
+            objs1.append(obj1)
+            objs2.append(obj2)
+        objs1 = torch.stack(objs1, dim=0)
+        objs2 = torch.stack(objs2, dim=0)
+        objs = [objs1, objs2]
+
+        for idx, obj in enumerate(objs):
+           total_loss += self.get_losses(out_for_loss[idx], obj, num_channels[idx])
+        
+        return total_loss
+
+    def get_objectness_indicators(self, bboxes, labels, anchors, num_channels, img_size):
+        targets = [torch.zeros((self.num_anchors, nc, nc, 6)) for nc in num_channels]
+        anchors = [[tuple(anchor[i : i + 2]) for i in range(0, len(anchor), 2)] for anchor in anchors]
+        anchors = torch.tensor(anchors[0] + anchors[1])
+        for box, class_label in zip(bboxes, labels):
+            iou_anchors = iou_width_height(box[2:4], anchors)
+            anchor_indices = iou_anchors.argsort(descending=True, dim=0)
+            x, y, width, height = box
+            has_anchor = [False] * 2
+
+        for anchor_idx in anchor_indices:
+            scale_idx = anchor_idx // self.num_anchors
+            anchor_on_scale = anchor_idx % self.num_anchors
+            S = num_channels[scale_idx]
+            i, j = int(S * y/img_size), int(S * x/img_size) # which cell
+
+            anchor_taken = targets[scale_idx][anchor_on_scale, i, j, 0]
+
+            if not anchor_taken and not has_anchor[scale_idx]:
+                targets[scale_idx][anchor_on_scale, i, j, 0] = 1
+                x_cell, y_cell = S * x - j, S * y - i # both between [0,1]
+                width_cell, height_cell = (width, height,) # can be greater than 1 since it's relative to cell
+                box_coordinates = torch.tensor([x_cell, y_cell, width_cell, height_cell])
+                targets[scale_idx][anchor_on_scale, i, j, 1:5] = box_coordinates
+                targets[scale_idx][anchor_on_scale, i, j, 5] = int(class_label)
+                has_anchor[scale_idx] = True
+            elif not anchor_taken and iou_anchors[anchor_idx] > self.ignore_iou_threshold:
+                targets[scale_idx][anchor_on_scale, i, j, 0] = 0 # ignore prediction
+
+        return targets
 
 
+    def get_losses(self, preds, objs, num_channel):
+        pred = preds.view(-1, self.num_anchors, num_channel, num_channel, 5+self.num_classes)
+        target = objs.view(-1, self.num_anchors, num_channel, num_channel, 6)
+        obj = target[..., 0] == 1
+        noobj = target[..., 0] == 0
+
+        no_object_loss = self.bce(
+            pred[..., 4:5][noobj], target[..., 0:1][noobj],
+        )
+
+        box_preds = pred[..., :4]
+        ious = intersection_over_union(box_preds[obj], target[..., 1:5][obj]).detach()
+
+        object_loss = self.mse(self.sigmoid(pred[..., 4:5][obj]), ious * target[..., 0:1][obj])
+        box_loss = self.mse(pred[..., 1:5][obj], target[..., 1:5][obj])
+        class_loss = self.entropy(
+            pred[..., 5:][obj], target[..., 5][obj].long()
+        )
+
+        return self.lambda_noobj * no_object_loss + self.lambda_coord * box_loss + class_loss + object_loss
 
 
+    def get_output_and_grid(self, output, k, stride, dtype):
+        grid = self.grids[k]
+        num_anchors = self.num_anchors
+        anchors = torch.tensor(self.anchors[k]).to(output.device)
+        anchors = anchors.view(1, num_anchors, 1, 2)
+        batch_size = output.shape[0]
+        n_ch = 5 + self.num_classes
+        hsize, wsize = output.shape[-2:]
+        if grid.shape[2:4] != output.shape[2:4]:
+            yv, xv = torch.meshgrid(torch.arange(hsize), torch.arange(wsize), indexing="ij")
+            grid = torch.stack((xv, yv), 2).view(1, 1, hsize, wsize, 2).type(dtype)
+            self.grids[k] = grid
+        output = output.view(batch_size, self.num_anchors, n_ch, hsize, wsize) # [8, 3, 85, h, w]
+        output = output.permute(0, 1, 3, 4, 2).reshape(batch_size, -1, hsize * wsize, n_ch)
+        grid = grid.view(1, 1, -1, 2)
+        output = torch.cat([
+                            torch.sigmoid(output[..., :2]) + grid, # cx and cy
+                            torch.exp(output[..., 2:4]) * anchors, # box_width and box_height
+                            output[..., 4:5], # confidence score: sigmoid를 사용하지 않는 이유는 BCE with logit loss를 사용하기 때문이다.
+                            output[..., 5:] # cls prob
+                            ], dim=-1)
+        return output, grid
+
+
+    def get_offsets_and_out(self, preds, img_size):
+        x_shifts = list()
+        y_shifts = list()
+        out_for_loss = list()
+        expanded_strides = list()
+        for k, o in enumerate(preds):
+            stride_this_level = img_size // o.size(-1)
+            o, grid = self.get_output_and_grid(o, k, stride_this_level, o.type())
+            x_shifts.append(grid[:, :, 0])
+            y_shifts.append(grid[:, :, 1])
+            expanded_strides.append(
+                            torch.zeros(1, grid.shape[1]).fill_(stride_this_level).type_as(o))
+            out_for_loss.append(o)
+        # out_for_loss: [2, B, na, c*c, 85]
+
+        return x_shifts, y_shifts, expanded_strides, out_for_loss

--- a/src/netspresso_trainer/losses/detection/yolo_fastest.py
+++ b/src/netspresso_trainer/losses/detection/yolo_fastest.py
@@ -174,7 +174,7 @@ class YOLOFastestLoss(nn.Module):
 
                 # Regression
                 pxy = pxy.sigmoid()
-                pwh = pwh * torch.log(1e-16 + anchors[i])
+                pwh = torch.exp(pwh) * anchors[i]
                 pbox = torch.cat((pxy, pwh), 1)  # predicted box
                 iou = bbox_iou(pbox, tbox[i], CIoU=True).squeeze()  # iou(prediction, target)
                 lbox += (1.0 - iou).mean()  # iou loss
@@ -280,7 +280,7 @@ class YOLOFastestLoss(nn.Module):
 
             # Append
             indices.append((b, a, gj.clamp_(0, shape[2] - 1), gi.clamp_(0, shape[3] - 1)))  # image, anchor, grid
-            tbox.append(torch.cat((gxy - gij, torch.log(1e-16 + gwh)), 1))  # box
+            tbox.append(torch.cat((gxy - gij, gwh), 1))  # box
             anch.append(anchors[a])  # anchors
             tcls.append(c)  # class
 

--- a/src/netspresso_trainer/losses/detection/yolo_fastest.py
+++ b/src/netspresso_trainer/losses/detection/yolo_fastest.py
@@ -1,0 +1,15 @@
+import torch 
+import torch.nn as nn
+from typing import List, Dict  
+
+
+class YOLOFastestLoss(nn.Module):
+    def __init__(self) -> None:
+        super(YOLOFastestLoss, self).__init__()
+    
+    def forward(self, out: List, target: Dict) -> torch.Tensor:
+        pass 
+
+
+
+

--- a/src/netspresso_trainer/losses/registry.py
+++ b/src/netspresso_trainer/losses/registry.py
@@ -1,5 +1,5 @@
 from .common import CrossEntropyLoss, SigmoidFocalLoss
-from .detection import RetinaNetLoss, YOLOXLoss
+from .detection import RetinaNetLoss, YOLOXLoss, YOLOFastestLoss
 from .pose_estimation import RTMCCLoss
 from .segmentation import PIDNetLoss
 
@@ -10,6 +10,7 @@ LOSS_DICT = {
     'retinanet_loss': RetinaNetLoss,
     'focal_loss': SigmoidFocalLoss,
     'rtmcc_loss': RTMCCLoss,
+    'yolo_fastest_loss': YOLOFastestLoss,
 }
 
 PHASE_LIST = ['train', 'valid', 'test']

--- a/src/netspresso_trainer/models/heads/detection/experimental/yolo_fastest_head.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/yolo_fastest_head.py
@@ -7,8 +7,7 @@ import torch.nn as nn
 
 
 from ....op.custom import ConvLayer
-from ....utils import AnchorBasedDetectionModelOutput
-from .detection import AnchorGenerator
+from ....utils import ModelOutput
 
 # TODO: Expand features to make it fully compatible with Yolov3 head and change the name to Yolov3Head
 class YoloFastestHead(nn.Module):
@@ -67,12 +66,11 @@ class YoloFastestHead(nn.Module):
         self.apply(init_bn)
 
     def forward(self, inputs: List[torch.Tensor]):
-
         x1, x2 = inputs
         out1 = self.layer_1(x1)
         out2 = self.layer_2(x2)
-
-        return out1, out2
+        output = [out1, out2]
+        return ModelOutput({'pred': output})
 
 
 def yolo_fastest_head(

--- a/src/netspresso_trainer/postprocessors/detection.py
+++ b/src/netspresso_trainer/postprocessors/detection.py
@@ -9,6 +9,10 @@ from torchvision.ops import boxes as box_ops
 from ..models.utils import ModelOutput
 
 
+def anchor_coupled_head_decode(pred, original_shape, topk_candiates=1000, score_thres=0.05):
+    pass 
+
+
 def anchor_decoupled_head_decode(pred, original_shape, topk_candidates=1000, score_thresh=0.05):
     box_coder = BoxCoder(weights=(1.0, 1.0, 1.0, 1.0))
 
@@ -156,6 +160,9 @@ class DetectionPostprocessor:
         elif head_name == 'anchor_decoupled_head':
             self.decode_outputs = partial(anchor_decoupled_head_decode, topk_candidates=params.topk_candidates, score_thresh=params.score_thresh)
             self.postprocess = partial(nms, nms_thresh=params.nms_thresh, class_agnostic=params.class_agnostic)
+        elif head_name == 'anchor_coupled_head':
+            self.decode_outputs = partial()
+
         else:
             self.decode_outputs = None
             self.postprocess = None

--- a/src/netspresso_trainer/postprocessors/detection.py
+++ b/src/netspresso_trainer/postprocessors/detection.py
@@ -8,19 +8,6 @@ from torchvision.ops import boxes as box_ops
 
 from ..models.utils import ModelOutput
 
-# def make_grid(pi, nx=20, ny=20, i=0, anchor=[]):
-#     s = 256  # 2x min stride
-#     stride = torch.tensor([s / pi.shape[-2]])
-#     d = pi.device
-#     t = pi.dtype
-#     shape = 1, pi.shape[1], ny, nx, 2  # grid shape
-#     y, x = torch.arange(ny, device=d, dtype=t), torch.arange(nx, device=d, dtype=t)
-#     yv, xv = torch.meshgrid(y, x, indexing='ij')
-#     grid = torch.stack((xv, yv), 2).expand(shape) - 0.5  # add grid offset, i.e. y = 2.0 * x - 0.5
-#     anchor_grid = (anchor * stride).view((1, pi.shape[1], 1, 1, 2)).expand(shape)
-#     return grid, anchor_grid
-
-
 
 def anchor_coupled_head_decode(pred, original_shape, anchors=[[12,10, 11,28, 24,17], [45,21, 24,60, 92,73]], topk_candidates=1000, score_thresh=0.05):
     pred = pred['pred']

--- a/src/netspresso_trainer/postprocessors/detection.py
+++ b/src/netspresso_trainer/postprocessors/detection.py
@@ -161,7 +161,9 @@ class DetectionPostprocessor:
             self.decode_outputs = partial(anchor_decoupled_head_decode, topk_candidates=params.topk_candidates, score_thresh=params.score_thresh)
             self.postprocess = partial(nms, nms_thresh=params.nms_thresh, class_agnostic=params.class_agnostic)
         elif head_name == 'anchor_coupled_head':
-            self.decode_outputs = partial()
+            # TODO: implement decoder and postprocessor
+            self.decode_outputs = None 
+            self.postprocess = None  
 
         else:
             self.decode_outputs = None

--- a/src/netspresso_trainer/postprocessors/registry.py
+++ b/src/netspresso_trainer/postprocessors/registry.py
@@ -12,4 +12,5 @@ POSTPROCESSOR_DICT = {
     'pidnet': SegmentationPostprocessor,
     'anchor_decoupled_head': DetectionPostprocessor,
     'rtmcc': PoseEstimationPostprocessor,
+    'yolo_fastest_head': DetectionPostprocessor,
 }


### PR DESCRIPTION
## Description

This PR is the part of our aims to support yolo-fastest model (#376). Especially, It contains features to add required postprocessor and loss functions. Although the loss decreases during training, metrics (i.e., mAP50, 75, 50-95) don’t increase and remain as zeros. I think there need some investigation to fix this issue.. 

## Change(s)

- Add required post-processor and loss modules

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`.

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`[CHANGELOG.md](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md)`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](<https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023>)

```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.