### PR TITLE
Change attention bias interpolate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ No changes to highlight.
 
 ## Other Changes:
 
-No changes to highlight.
+- Change attention bias interpolate method by `@illian01` in [PR 468](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/468)
 
 # v0.2.2
 

--- a/src/netspresso_trainer/models/op/base_metaformer.py
+++ b/src/netspresso_trainer/models/op/base_metaformer.py
@@ -199,7 +199,7 @@ class MultiHeadAttention(nn.Module):
 
         if self.use_attention_bias:
             bias = self.attention_biases[:, self.attention_bias_idxs]
-            bias = nn.functional.interpolate(bias.unsqueeze(0), size=(attention_scores.size(-2), attention_scores.size(-1)), mode='bicubic')
+            bias = nn.functional.interpolate(bias.unsqueeze(0), size=(attention_scores.size(-2), attention_scores.size(-1)), mode='bilinear')
             attention_scores = attention_scores + bias
 
         # Normalize the attention scores to probabilities.


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #463

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Enable convert Efficientformer to TensorRT
  - Change attention bias interpolate method to `bilinear`
  - `bicubic` is not supported in JetPack 5.0.1, this started at JetPack 6.0.0

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.