### PR TITLE
Separate the postprocessor configs from head.params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## New Features:
 
 - Add YOLOX-nano and YOLOX-tiny by `@hglee98` in [PR 467](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/467)
+- Separate postprocessor configuration hierarchy by `@hglee98` in [PR 470](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/470)
 
 ## Bug Fixes:
 

--- a/config/benchmark_examples/classification-imagenet1k-resnet18/model.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet18/model.yaml
@@ -38,7 +38,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20 
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.

--- a/config/benchmark_examples/classification-imagenet1k-resnet18/model.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet18/model.yaml
@@ -38,6 +38,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.

--- a/config/benchmark_examples/classification-imagenet1k-resnet34/model.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet34/model.yaml
@@ -38,7 +38,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20 
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.

--- a/config/benchmark_examples/classification-imagenet1k-resnet34/model.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet34/model.yaml
@@ -38,6 +38,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.

--- a/config/benchmark_examples/classification-imagenet1k-resnet50/model.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet50/model.yaml
@@ -38,6 +38,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/benchmark_examples/classification-imagenet1k-resnet50/model.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet50/model.yaml
@@ -38,7 +38,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20 
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/benchmark_examples/detection-coco2017-yolox_s/model.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/model.yaml
@@ -26,12 +26,13 @@ model:
       name: anchor_free_decoupled_head
       params:
         act_type: *act_type
-        # postprocessor - decode
-        score_thresh: 0.01
-        # postprocessor - nms
-        nms_thresh: 0.65
-        class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/benchmark_examples/detection-coco2017-yolox_s/model.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/model.yaml
@@ -31,6 +31,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.65
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/efficientformer/efficientformer-l1-classification.yaml
+++ b/config/model/efficientformer/efficientformer-l1-classification.yaml
@@ -41,6 +41,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/efficientformer/efficientformer-l1-classification.yaml
+++ b/config/model/efficientformer/efficientformer-l1-classification.yaml
@@ -41,7 +41,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/efficientformer/efficientformer-l1-detection.yaml
+++ b/config/model/efficientformer/efficientformer-l1-detection.yaml
@@ -48,14 +48,15 @@ model:
         anchor_sizes: [[32,], [64,], [128,], [256,]]
         aspect_ratios: [0.5, 1.0, 2.0]
         num_layers: 1
-        norm_type: batch_norm
-        # postprocessor - decode
-        topk_candidates: 1000
-        score_thresh: 0.05
-        # postprocessor - nms
-        nms_thresh: 0.45
-        class_agnostic: False
-  postprocessor: ~
+        norm_type: batch_norm   
+  postprocessor: 
+    params:
+      # postprocessor - decode
+      topk_candidates: 1000
+      score_thresh: 0.05
+      # postprocessor - nms
+      nms_thresh: 0.45
+      class_agnostic: False
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/efficientformer/efficientformer-l1-detection.yaml
+++ b/config/model/efficientformer/efficientformer-l1-detection.yaml
@@ -55,6 +55,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/efficientformer/efficientformer-l1-segmentation.yaml
+++ b/config/model/efficientformer/efficientformer-l1-segmentation.yaml
@@ -39,6 +39,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/mixnet/mixnet-l-classification.yaml
+++ b/config/model/mixnet/mixnet-l-classification.yaml
@@ -65,6 +65,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mixnet/mixnet-l-classification.yaml
+++ b/config/model/mixnet/mixnet-l-classification.yaml
@@ -65,7 +65,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -79,6 +79,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -73,12 +73,6 @@ model:
         aspect_ratios: [0.5, 1.0, 2.0]
         num_layers: 1
         norm_type: batch_norm
-        # postprocessor - decode
-        topk_candidates: 1000
-        score_thresh: 0.05
-        # postprocessor - nms
-        nms_thresh: 0.45
-        class_agnostic: False
   postprocessor: 
     params:
       # postprocessor - decode

--- a/config/model/mixnet/mixnet-l-detection.yaml
+++ b/config/model/mixnet/mixnet-l-detection.yaml
@@ -79,7 +79,14 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params:
+      # postprocessor - decode
+      topk_candidates: 1000
+      score_thresh: 0.05
+      # postprocessor - nms
+      nms_thresh: 0.45
+      class_agnostic: False
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mixnet/mixnet-l-segmentation.yaml
+++ b/config/model/mixnet/mixnet-l-segmentation.yaml
@@ -63,6 +63,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/mixnet/mixnet-m-classification.yaml
+++ b/config/model/mixnet/mixnet-m-classification.yaml
@@ -65,6 +65,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mixnet/mixnet-m-classification.yaml
+++ b/config/model/mixnet/mixnet-m-classification.yaml
@@ -65,7 +65,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -79,6 +79,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -73,12 +73,6 @@ model:
         aspect_ratios: [0.5, 1.0, 2.0]
         num_layers: 1
         norm_type: batch_norm
-        # postprocessor - decode
-        topk_candidates: 1000
-        score_thresh: 0.05
-        # postprocessor - nms
-        nms_thresh: 0.45
-        class_agnostic: False
   postprocessor: 
     params:
       # postprocessor - decode

--- a/config/model/mixnet/mixnet-m-detection.yaml
+++ b/config/model/mixnet/mixnet-m-detection.yaml
@@ -79,7 +79,14 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params:
+      # postprocessor - decode
+      topk_candidates: 1000
+      score_thresh: 0.05
+      # postprocessor - nms
+      nms_thresh: 0.45
+      class_agnostic: False
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mixnet/mixnet-m-segmentation.yaml
+++ b/config/model/mixnet/mixnet-m-segmentation.yaml
@@ -63,6 +63,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/mixnet/mixnet-s-classification.yaml
+++ b/config/model/mixnet/mixnet-s-classification.yaml
@@ -65,6 +65,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mixnet/mixnet-s-classification.yaml
+++ b/config/model/mixnet/mixnet-s-classification.yaml
@@ -65,7 +65,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -79,6 +79,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -73,12 +73,6 @@ model:
         aspect_ratios: [0.5, 1.0, 2.0]
         num_layers: 1
         norm_type: batch_norm
-        # postprocessor - decode
-        topk_candidates: 1000
-        score_thresh: 0.05
-        # postprocessor - nms
-        nms_thresh: 0.45
-        class_agnostic: False
   postprocessor: 
     params:
       # postprocessor - decode

--- a/config/model/mixnet/mixnet-s-detection.yaml
+++ b/config/model/mixnet/mixnet-s-detection.yaml
@@ -79,7 +79,14 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params:
+      # postprocessor - decode
+      topk_candidates: 1000
+      score_thresh: 0.05
+      # postprocessor - nms
+      nms_thresh: 0.45
+      class_agnostic: False
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mixnet/mixnet-s-segmentation.yaml
+++ b/config/model/mixnet/mixnet-s-segmentation.yaml
@@ -63,6 +63,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/mobilenetv3/mobilenetv3-large-classification.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-large-classification.yaml
@@ -53,6 +53,7 @@ model:
         intermediate_channels: 1280
         act_type: hard_swish
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mobilenetv3/mobilenetv3-large-classification.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-large-classification.yaml
@@ -53,7 +53,9 @@ model:
         intermediate_channels: 1280
         act_type: hard_swish
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
@@ -53,6 +53,7 @@ model:
         intermediate_channels: 1024
         act_type: hard_swish
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-classification.yaml
@@ -53,7 +53,9 @@ model:
         intermediate_channels: 1024
         act_type: hard_swish
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -67,6 +67,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -67,7 +67,14 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params:
+      # postprocessor - decode
+      topk_candidates: 1000
+      score_thresh: 0.05
+      # postprocessor - nms
+      nms_thresh: 0.45
+      class_agnostic: False
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-detection.yaml
@@ -61,12 +61,6 @@ model:
         aspect_ratios: [0.5, 1.0, 2.0]
         num_layers: 1
         norm_type: batch_norm
-        # postprocessor - decode
-        topk_candidates: 1000
-        score_thresh: 0.05
-        # postprocessor - nms
-        nms_thresh: 0.45
-        class_agnostic: False
   postprocessor: 
     params:
       # postprocessor - decode

--- a/config/model/mobilenetv3/mobilenetv3-small-segmentation.yaml
+++ b/config/model/mobilenetv3/mobilenetv3-small-segmentation.yaml
@@ -51,6 +51,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/mobilevit/mobilevit-s-classification.yaml
+++ b/config/model/mobilevit/mobilevit-s-classification.yaml
@@ -66,6 +66,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/mobilevit/mobilevit-s-classification.yaml
+++ b/config/model/mobilevit/mobilevit-s-classification.yaml
@@ -66,7 +66,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/pidnet/pidnet-s-segmentation.yaml
+++ b/config/model/pidnet/pidnet-s-segmentation.yaml
@@ -18,6 +18,7 @@ model:
       head_channels: 128
     backbone: ~
     head: ~
+  postprocessor: ~
   losses:
     - criterion: pidnet_loss
       weight: ~

--- a/config/model/resnet/resnet18-classification.yaml
+++ b/config/model/resnet/resnet18-classification.yaml
@@ -38,6 +38,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/resnet/resnet18-classification.yaml
+++ b/config/model/resnet/resnet18-classification.yaml
@@ -38,7 +38,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/resnet/resnet34-classification.yaml
+++ b/config/model/resnet/resnet34-classification.yaml
@@ -38,6 +38,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/resnet/resnet34-classification.yaml
+++ b/config/model/resnet/resnet34-classification.yaml
@@ -38,7 +38,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/resnet/resnet50-classification.yaml
+++ b/config/model/resnet/resnet50-classification.yaml
@@ -38,6 +38,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/resnet/resnet50-classification.yaml
+++ b/config/model/resnet/resnet50-classification.yaml
@@ -38,7 +38,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -52,7 +52,14 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params:
+      # postprocessor - decode
+      topk_candidates: 1000
+      score_thresh: 0.05
+      # postprocessor - nms
+      nms_thresh: 0.45
+      class_agnostic: False
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -52,6 +52,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.45
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: retinanet_loss
       weight: ~

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -46,12 +46,6 @@ model:
         aspect_ratios: [0.5, 1.0, 2.0]
         num_layers: 1
         norm_type: batch_norm
-        # postprocessor - decode
-        topk_candidates: 1000
-        score_thresh: 0.05
-        # postprocessor - nms
-        nms_thresh: 0.45
-        class_agnostic: False
   postprocessor: 
     params:
       # postprocessor - decode

--- a/config/model/resnet/resnet50-segmentation.yaml
+++ b/config/model/resnet/resnet50-segmentation.yaml
@@ -37,6 +37,7 @@ model:
       params:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/rtmpose/rtmpose-pose_estimation.yaml
+++ b/config/model/rtmpose/rtmpose-pose_estimation.yaml
@@ -62,6 +62,7 @@ model:
         simcc_split_ratio: 2.
         target_size: [256, 256]
         backbone_stride: 32
+  postprocessor: ~
   losses:
     - criterion: rtmcc_loss
       weight: ~

--- a/config/model/rtmpose/rtmpose-pose_estimation.yaml
+++ b/config/model/rtmpose/rtmpose-pose_estimation.yaml
@@ -62,7 +62,9 @@ model:
         simcc_split_ratio: 2.
         target_size: [256, 256]
         backbone_stride: 32
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      simcc_split_ratio: 2.
   losses:
     - criterion: rtmcc_loss
       weight: ~

--- a/config/model/segformer/segformer-b0-segmentation.yaml
+++ b/config/model/segformer/segformer-b0-segmentation.yaml
@@ -52,6 +52,7 @@ model:
         intermediate_channels: 256
         classifier_dropout_prob: 0.
         resize_output: [512, 512]
+  postprocessor: ~
   losses:
     - criterion: seg_cross_entropy
       weight: ~

--- a/config/model/vit/vit-tiny-classification.yaml
+++ b/config/model/vit/vit-tiny-classification.yaml
@@ -30,6 +30,7 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/vit/vit-tiny-classification.yaml
+++ b/config/model/vit/vit-tiny-classification.yaml
@@ -30,7 +30,9 @@ model:
         intermediate_channels: ~
         act_type: ~
         dropout_prob: 0.
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      topk_max: 20
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1

--- a/config/model/yolox/yolox-l-detection.yaml
+++ b/config/model/yolox/yolox-l-detection.yaml
@@ -34,6 +34,7 @@ model:
         nms_thresh: 0.65
         class_agnostic: False
         depthwise: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-l-detection.yaml
+++ b/config/model/yolox/yolox-l-detection.yaml
@@ -27,14 +27,15 @@ model:
     head:
       name: anchor_free_decoupled_head
       params:
-        act_type: *act_type
-        # postprocessor - decode
-        score_thresh: 0.01
-        # postprocessor - nms
-        nms_thresh: 0.65
-        class_agnostic: False
+        act_type: *act_type 
         depthwise: False
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-m-detection.yaml
+++ b/config/model/yolox/yolox-m-detection.yaml
@@ -34,6 +34,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.65
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-m-detection.yaml
+++ b/config/model/yolox/yolox-m-detection.yaml
@@ -28,13 +28,14 @@ model:
       name: anchor_free_decoupled_head
       params:
         depthwise: False
-        act_type: *act_type
-        # postprocessor - decode
-        score_thresh: 0.01
-        # postprocessor - nms
-        nms_thresh: 0.65
-        class_agnostic: False
-  postprocessor: ~
+        act_type: *act_type 
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-nano-detection.yaml
+++ b/config/model/yolox/yolox-nano-detection.yaml
@@ -32,6 +32,7 @@ model:
         score_thresh: 0.01  # decode
         nms_thresh: 0.65  # nms
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-nano-detection.yaml
+++ b/config/model/yolox/yolox-nano-detection.yaml
@@ -28,11 +28,14 @@ model:
       name: anchor_free_decoupled_head
       params:
         depthwise: True
-        act_type: *act_type
-        score_thresh: 0.01  # decode
-        nms_thresh: 0.65  # nms
-        class_agnostic: False
-  postprocessor: ~
+        act_type: *act_type 
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-s-detection.yaml
+++ b/config/model/yolox/yolox-s-detection.yaml
@@ -32,6 +32,7 @@ model:
         score_thresh: 0.01  # decode
         nms_thresh: 0.65  # nms
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-s-detection.yaml
+++ b/config/model/yolox/yolox-s-detection.yaml
@@ -29,10 +29,13 @@ model:
       params:
         depthwise: False
         act_type: *act_type
-        score_thresh: 0.01  # decode
-        nms_thresh: 0.65  # nms
-        class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-tiny-detection.yaml
+++ b/config/model/yolox/yolox-tiny-detection.yaml
@@ -32,6 +32,7 @@ model:
         score_thresh: 0.01  # decode
         nms_thresh: 0.65  # nms
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-tiny-detection.yaml
+++ b/config/model/yolox/yolox-tiny-detection.yaml
@@ -29,10 +29,13 @@ model:
       params:
         depthwise: False
         act_type: *act_type
-        score_thresh: 0.01  # decode
-        nms_thresh: 0.65  # nms
-        class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-x-detection.yaml
+++ b/config/model/yolox/yolox-x-detection.yaml
@@ -29,12 +29,13 @@ model:
       params:
         depthwise: False
         act_type: *act_type
-        # postprocessor - decode
-        score_thresh: 0.01
-        # postprocessor - nms
-        nms_thresh: 0.65
-        class_agnostic: False
-  postprocessor: ~
+  postprocessor: 
+    params: 
+      # postprocessor - decode
+      score_thresh: 0.01
+      # postprocessor - nms
+      nms_thresh: 0.65
+      class_agnostic: False
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/config/model/yolox/yolox-x-detection.yaml
+++ b/config/model/yolox/yolox-x-detection.yaml
@@ -34,6 +34,7 @@ model:
         # postprocessor - nms
         nms_thresh: 0.65
         class_agnostic: False
+  postprocessor: ~
   losses:
     - criterion: yolox_loss
       weight: ~

--- a/docs/components/model/overview.md
+++ b/docs/components/model/overview.md
@@ -20,6 +20,7 @@ model:
     backbone: ...
     neck: ...
     head: ...
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1
@@ -42,6 +43,7 @@ model:
     optimizer_path: # This field will be ignored since fx_model_path is activated
   freeze_backbone: False
   architecture: # This field will be ignored since fx_model_path is activated
+  postprocessor: ~
   losses:
     - criterion: cross_entropy
       label_smoothing: 0.1
@@ -63,4 +65,5 @@ model:
 | `model.checkpoint.fx_model_path` | (str) Model path for fx model retraining. If you have to train the model from NP Compressor, you have to fill your compressed model path at this field. If `fx_model_path` is filled, `use_pretrained`, `load_head`, `path`, `optimizer_path`, and `freeze_backbone` are ignored. |
 | `model.freeze_backbone` | (bool) Whether to freeze backbone in training. |
 | `model.architecture` | (dict) Detailed configuration of the model architecture. Please see [Model page](../../../models/overview) to find NetsPresso supporting models. |
+| `model.postprocessor` | (dict) Detailed configuration of the model postprocessor. Please see [Postprocessor page](../postprocessor/)|
 | `model.losses` | (list) List of losses that model to learn. Please see [Losses page](../losses/) to find NetsPresso supporting loss modules. |

--- a/docs/components/model/postprocessor.md
+++ b/docs/components/model/postprocessor.md
@@ -1,0 +1,1 @@
+# Postprocessor

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -6,7 +6,7 @@ NetsPresso Trainer categorizes essential parameters for training into six config
 
 - **Data**: Defines the structure of the user-customized or Hugging Face datasets for interpretation by NetsPresso Trainer.
 - **Augmentation**: Defines the data augmentation recipe.
-- **Model**: Defines the model architecture, loss modules, and pretrained weights.
+- **Model**: Defines the model architecture, postprocessor modules, loss modules, and pretrained weights.
 - **Training**: Defines necessary elements like optimizer, epochs, and batch size for training.
 - **Logging**: Defines output formats of training results.
 - **Environment**: Defines the training environment, including GPU usage and dataloader multi-processing.

--- a/src/netspresso_trainer/postprocessors/classification.py
+++ b/src/netspresso_trainer/postprocessors/classification.py
@@ -22,8 +22,8 @@ from ..models.utils import ModelOutput
 
 class ClassificationPostprocessor():
     def __init__(self, conf_model):
-        self.params = conf_model.postprocessor.params
-        self.topk_max = self.params.topk_max
+        params = conf_model.postprocessor.params
+        self.topk_max = params.topk_max
 
     def __call__(self, outputs: ModelOutput, k: Optional[int]=None):
         pred = outputs['pred']

--- a/src/netspresso_trainer/postprocessors/classification.py
+++ b/src/netspresso_trainer/postprocessors/classification.py
@@ -23,10 +23,11 @@ from ..models.utils import ModelOutput
 class ClassificationPostprocessor():
     def __init__(self, conf_model):
         self.params = conf_model.postprocessor.params
+        self.topk_max = self.params.topk_max
 
     def __call__(self, outputs: ModelOutput, k: Optional[int]=None):
         pred = outputs['pred']
-        maxk = min(self.params.topk_max, pred.size()[1])
+        maxk = min(self.topk_max, pred.size()[1])
         if k:
             maxk = min(k, maxk)
         _, pred = pred.topk(maxk, 1, True, True)

--- a/src/netspresso_trainer/postprocessors/classification.py
+++ b/src/netspresso_trainer/postprocessors/classification.py
@@ -19,7 +19,6 @@ from typing import Optional
 from ..models.utils import ModelOutput
 
 
-
 class ClassificationPostprocessor():
     def __init__(self, conf_model):
         params = conf_model.postprocessor.params

--- a/src/netspresso_trainer/postprocessors/classification.py
+++ b/src/netspresso_trainer/postprocessors/classification.py
@@ -18,16 +18,15 @@ from typing import Optional
 
 from ..models.utils import ModelOutput
 
-TOPK_MAX = 20
 
 
 class ClassificationPostprocessor():
     def __init__(self, conf_model):
-        pass
+        self.params = conf_model.postprocessor.params
 
     def __call__(self, outputs: ModelOutput, k: Optional[int]=None):
         pred = outputs['pred']
-        maxk = min(TOPK_MAX, pred.size()[1])
+        maxk = min(self.params.topk_max, pred.size()[1])
         if k:
             maxk = min(k, maxk)
         _, pred = pred.topk(maxk, 1, True, True)

--- a/src/netspresso_trainer/postprocessors/detection.py
+++ b/src/netspresso_trainer/postprocessors/detection.py
@@ -165,7 +165,7 @@ def nms(prediction, nms_thresh=0.45, class_agnostic=False):
 class DetectionPostprocessor:
     def __init__(self, conf_model):
         head_name = conf_model.architecture.head.name
-        params = conf_model.architecture.head.params
+        params = conf_model.postprocessor.params
         if head_name == 'anchor_free_decoupled_head':
             self.decode_outputs = partial(anchor_free_decoupled_head_decode, score_thresh=params.score_thresh)
             self.postprocess = partial(nms, nms_thresh=params.nms_thresh, class_agnostic=params.class_agnostic)

--- a/src/netspresso_trainer/postprocessors/pose_estimation.py
+++ b/src/netspresso_trainer/postprocessors/pose_estimation.py
@@ -27,8 +27,8 @@ from ..models.utils import ModelOutput
 
 class PoseEstimationPostprocessor():
     def __init__(self, conf_model):
-        # TODO: Get from config
-        self.simcc_split_ratio = 2.
+        self.params = conf_model.postprocessor.params
+        self.simcc_split_ratio = self.params.simcc_split_ratio
 
     def get_simcc_maximum(self, simcc_x, simcc_y, apply_softmax: bool = False):
         assert simcc_x.ndim == 2 or simcc_x.ndim == 3, (f'Invalid shape {simcc_x.shape}')

--- a/src/netspresso_trainer/postprocessors/pose_estimation.py
+++ b/src/netspresso_trainer/postprocessors/pose_estimation.py
@@ -27,8 +27,8 @@ from ..models.utils import ModelOutput
 
 class PoseEstimationPostprocessor():
     def __init__(self, conf_model):
-        self.params = conf_model.postprocessor.params
-        self.simcc_split_ratio = self.params.simcc_split_ratio
+        params = conf_model.postprocessor.params
+        self.simcc_split_ratio = params.simcc_split_ratio
 
     def get_simcc_maximum(self, simcc_x, simcc_y, apply_softmax: bool = False):
         assert simcc_x.ndim == 2 or simcc_x.ndim == 3, (f'Invalid shape {simcc_x.shape}')

--- a/src/netspresso_trainer/postprocessors/segmentation.py
+++ b/src/netspresso_trainer/postprocessors/segmentation.py
@@ -24,7 +24,7 @@ from ..models.utils import ModelOutput
 
 class SegmentationPostprocessor:
     def __init__(self, conf_model):
-        self.params = conf_model.postprocessor.params        
+        params = conf_model.postprocessor.params        
     def __call__(self, outputs: ModelOutput, original_shape):
         pred = outputs['pred']
         H, W = original_shape[-2:]

--- a/src/netspresso_trainer/postprocessors/segmentation.py
+++ b/src/netspresso_trainer/postprocessors/segmentation.py
@@ -24,8 +24,7 @@ from ..models.utils import ModelOutput
 
 class SegmentationPostprocessor:
     def __init__(self, conf_model):
-        pass
-
+        self.params = conf_model.postprocessor.params        
     def __call__(self, outputs: ModelOutput, original_shape):
         pred = outputs['pred']
         H, W = original_shape[-2:]

--- a/src/netspresso_trainer/postprocessors/segmentation.py
+++ b/src/netspresso_trainer/postprocessors/segmentation.py
@@ -24,7 +24,7 @@ from ..models.utils import ModelOutput
 
 class SegmentationPostprocessor:
     def __init__(self, conf_model):
-        params = conf_model.postprocessor.params        
+        pass
     def __call__(self, outputs: ModelOutput, original_shape):
         pred = outputs['pred']
         H, W = original_shape[-2:]


### PR DESCRIPTION
## Description

This PR aims to separate postprocessor configs and make user being able to control parameters using only config files. 

Closes: #425 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add postprocessor config section for each config files 
- Refactor postprocessor to move hard-corded variables to config files
- Init postprocessor docs component 
- Update docs for postprocessor overview

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.