### PR TITLE
Remove output typing of PIDNet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ No changes to highlight.
 
 - Change attention bias interpolate method by `@illian01` in [PR 468](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/468)
 - Fix ViT token number in positional encoding for torch.fx compile step by `@illian01` in [PR 475](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/475)
+- Remove output typing of PIDNet by `@illian01` in [PR 477](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/477)
 
 # v0.2.2
 

--- a/src/netspresso_trainer/models/full/experimental/pidnet.py
+++ b/src/netspresso_trainer/models/full/experimental/pidnet.py
@@ -161,7 +161,7 @@ class PIDNet(nn.Module):
     def device(self):
         return next(self.parameters()).device
 
-    def forward(self, x: FXTensorType, label_size=None) -> PIDNetModelOutput:
+    def forward(self, x: FXTensorType, label_size=None):
 
         # assert H == x.size(2)
         # assert W == x.size(3)


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #476

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Remove output typing of PIDNet

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.