### PR TITLE
Fix handling error in case of error occured in first epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix handling error in case of error occured in first epoch by `@illian01` in [PR 493](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/493)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -262,6 +262,8 @@ class TrainingPipeline(BasePipeline):
     def save_best(self):
         valid_losses = {epoch: record['valid_losses'].get('total') for epoch, record in self.training_history.items()
                 if 'valid_losses' in record}
+        if not valid_losses:
+            return # No validation loss recorded
         best_epoch = min(valid_losses, key=valid_losses.get)
 
         logging_dir = self.logger.result_dir

--- a/src/netspresso_trainer/utils/record.py
+++ b/src/netspresso_trainer/utils/record.py
@@ -150,11 +150,8 @@ class TrainingSummary:
     error_stats: str = ""
 
     def __post_init__(self):
-        self.last_epoch = list(self.train_losses.keys())[-1]
-        try: # self.valid_losses is empty if validation is not performed
-            self.best_epoch = min(self.valid_losses, key=self.valid_losses.get)
-        except ValueError:
-            self.best_epoch = self.last_epoch
+        self.last_epoch = 1 if not self.train_losses else list(self.train_losses.keys())[-1] # self.train_losses is empty if error occurs before first epoch done
+        self.best_epoch = self.last_epoch if not self.valid_losses else min(self.valid_losses, key=self.valid_losses.get) # self.valid_losses is empty if validation is not performed
 
 @dataclass
 class EvaluationSummary:


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #(issue number)

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Fix handling error in case of error occured in first epoch

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.