### PR TITLE
Add ResNet model parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add RT-DETR by `@illian01` and `@hglee98` in [PR 490](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/490), [PR 491](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/491), [PR 494](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/494)
 - Add Objects365 dataset auto downloader by `@hglee98` in [PR 482](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/482)
+- Add ResNet model parameters to support various form by `@illian01` in [PR 497](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/497)
 
 ## Bug Fixes:
 

--- a/config/model/resnet/resnet18-classification.yaml
+++ b/config/model/resnet/resnet18-classification.yaml
@@ -3,7 +3,7 @@ model:
   name: resnet18
   checkpoint:
     use_pretrained: True
-    load_head: True
+    load_head: False
     path: ~
     fx_model_path: ~
     optimizer_path: ~

--- a/config/model/resnet/resnet18-classification.yaml
+++ b/config/model/resnet/resnet18-classification.yaml
@@ -3,7 +3,7 @@ model:
   name: resnet18
   checkpoint:
     use_pretrained: True
-    load_head: False
+    load_head: True
     path: ~
     fx_model_path: ~
     optimizer_path: ~
@@ -15,6 +15,9 @@ model:
       params:
         block_type: basicblock
         norm_type: batch_norm
+        return_stage_idx: ~
+        split_stem_conv: False
+        first_stage_shortcut_conv: False
       stage_params:
         - 
           channels: 64
@@ -23,14 +26,17 @@ model:
           channels: 128
           num_blocks: 2
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 256
           num_blocks: 2
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 512
           num_blocks: 2
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
     head:
       name: fc
       params:

--- a/config/model/resnet/resnet34-classification.yaml
+++ b/config/model/resnet/resnet34-classification.yaml
@@ -15,6 +15,9 @@ model:
       params:
         block_type: basicblock
         norm_type: batch_norm
+        return_stage_idx: ~
+        split_stem_conv: False
+        first_stage_shortcut_conv: False
       stage_params:
         - 
           channels: 64
@@ -23,14 +26,17 @@ model:
           channels: 128
           num_blocks: 4
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 256
           num_blocks: 6
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 512
           num_blocks: 3
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
     head:
       name: fc
       params:

--- a/config/model/resnet/resnet50-classification.yaml
+++ b/config/model/resnet/resnet50-classification.yaml
@@ -15,6 +15,9 @@ model:
       params:
         block_type: bottleneck
         norm_type: batch_norm
+        return_stage_idx: ~
+        split_stem_conv: False
+        first_stage_shortcut_conv: False
       stage_params:
         - 
           channels: 64
@@ -23,14 +26,17 @@ model:
           channels: 128
           num_blocks: 4
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 256
           num_blocks: 6
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 512
           num_blocks: 3
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
     head:
       name: fc
       params:

--- a/config/model/resnet/resnet50-detection.yaml
+++ b/config/model/resnet/resnet50-detection.yaml
@@ -15,6 +15,9 @@ model:
       params:
         block_type: bottleneck
         norm_type: batch_norm
+        return_stage_idx: [0, 1, 2, 3]
+        split_stem_conv: False
+        first_stage_shortcut_conv: False
       stage_params:
         - 
           channels: 64
@@ -23,14 +26,17 @@ model:
           channels: 128
           num_blocks: 4
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 256
           num_blocks: 6
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 512
           num_blocks: 3
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
     neck:
       name: fpn
       params:

--- a/config/model/resnet/resnet50-segmentation.yaml
+++ b/config/model/resnet/resnet50-segmentation.yaml
@@ -3,7 +3,7 @@ model:
   name: resnet50
   checkpoint:
     use_pretrained: True
-    load_head: False
+    load_head: True
     path: ~
     fx_model_path: ~
     optimizer_path: ~
@@ -16,6 +16,9 @@ model:
       params:
         block_type: bottleneck
         norm_type: batch_norm
+        return_stage_idx: ~
+        split_stem_conv: False
+        first_stage_shortcut_conv: False
       stage_params:
         - 
           channels: 64
@@ -24,14 +27,17 @@ model:
           channels: 128
           num_blocks: 4
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 256
           num_blocks: 6
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
         - 
           channels: 512
           num_blocks: 3
           replace_stride_with_dilation: False
+          replace_stride_with_pooling: False
     head:
       name: all_mlp_decoder
       params:

--- a/config/model/rtdetr/rtdetr-res18-detection.yaml
+++ b/config/model/rtdetr/rtdetr-res18-detection.yaml
@@ -1,23 +1,42 @@
 model:
   task: detection
-  name: yolox_s
+  name: rtdetr
   checkpoint:
     use_pretrained: True
     load_head: False
-    path: ~ 
+    path: ~
     fx_model_path: ~
     optimizer_path: ~
   freeze_backbone: False
   architecture:
     full: ~ # auto
     backbone:
-      name: cspdarknet
+      name: resnet
       params:
-        depthwise: False
-        dep_mul: &dep_mul 0.33
-        wid_mul: 0.5
-        act_type: &act_type "silu"
-      stage_params: ~
+        block_type: basicblock
+        norm_type: batch_norm
+        return_stage_idx: [1, 2, 3]
+        split_stem_conv: True
+        first_stage_shortcut_conv: True
+      stage_params:
+        - 
+          channels: 64
+          num_blocks: 2
+        - 
+          channels: 128
+          num_blocks: 2
+          replace_stride_with_dilation: False
+          replace_stride_with_pooling: True
+        - 
+          channels: 256
+          num_blocks: 2
+          replace_stride_with_dilation: False
+          replace_stride_with_pooling: True
+        - 
+          channels: 512
+          num_blocks: 2
+          replace_stride_with_dilation: False
+          replace_stride_with_pooling: True
     neck:
       name: rtdetr_hybrid_encoder
       params:

--- a/src/netspresso_trainer/models/backbones/core/resnet.py
+++ b/src/netspresso_trainer/models/backbones/core/resnet.py
@@ -51,7 +51,7 @@ class ResNet(nn.Module):
         self.task = task.lower()
         assert self.task in SUPPORTING_TASK, f'ResNet is not supported on {self.task} task now.'
         self.use_intermediate_features = self.task in USE_INTERMEDIATE_FEATURES_TASK_LIST
-        self.return_stage_idx = params.return_stage_idx
+        self.return_stage_idx = params.return_stage_idx if params.return_stage_idx else [-1]
         self.split_stem_conv = params.split_stem_conv
 
         super(ResNet, self).__init__()

--- a/src/netspresso_trainer/models/backbones/core/resnet.py
+++ b/src/netspresso_trainer/models/backbones/core/resnet.py
@@ -101,7 +101,8 @@ class ResNet(nn.Module):
         stages: List[nn.Module] = []
 
         first_stage = stage_params[0]
-        layer = self._make_layer(block, first_stage.channels, first_stage.num_blocks, expansion=expansion)
+        layer = self._make_layer(block, first_stage.channels, first_stage.num_blocks, 
+                                 expansion=expansion, downsample_flag=params.first_stage_shortcut_conv)
         stages.append(layer)
         for stage in stage_params[1:]:
             layer = self._make_layer(block, stage.channels, stage.num_blocks, stride=2,
@@ -134,7 +135,8 @@ class ResNet(nn.Module):
                     nn.init.constant_(m.bn2.weight, 0)  # type: ignore[arg-type]
 
     def _make_layer(self, block: Type[Union[BasicBlock, Bottleneck]], planes: int, blocks: int,
-                    stride: int = 1, dilate: bool = False, expansion: Optional[int] = None) -> nn.Sequential:
+                    stride: int = 1, dilate: bool = False, expansion: Optional[int] = None,
+                    downsample_flag: bool = False) -> nn.Sequential:
         norm_layer = self._norm_layer
         downsample = None
         previous_dilation = self.dilation
@@ -143,7 +145,7 @@ class ResNet(nn.Module):
         if dilate:
             self.dilation *= stride
             stride = 1
-        if stride != 1 or self.inplanes != planes * expansion:
+        if stride != 1 or self.inplanes != planes * expansion or downsample_flag:
             downsample = ConvLayer(
                 in_channels=self.inplanes, out_channels=planes * expansion,
                 kernel_size=1, stride=stride, bias=False,

--- a/src/netspresso_trainer/postprocessors/detection.py
+++ b/src/netspresso_trainer/postprocessors/detection.py
@@ -201,7 +201,7 @@ class DetectionPostprocessor:
             self.decode_outputs = partial(anchor_decoupled_head_decode, topk_candidates=params.topk_candidates, score_thresh=params.score_thresh)
             self.postprocess = partial(nms, nms_thresh=params.nms_thresh, class_agnostic=params.class_agnostic)
         elif head_name == 'rtdetr_head':
-            self.decode_outputs = partial(rtdetr_decode, num_top_queries=params.num_top_queries)
+            self.decode_outputs = partial(rtdetr_decode, num_top_queries=params.num_top_queries, score_thresh=params.score_thresh)
             self.postprocess = None
         else:
             self.decode_outputs = None


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #496

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add ResNet model parameters
  - `split_stem_conv`: split first 7x7 conv to three of 3x3 conv
  - `first_stage_shortcut_conv`: Add bottleneck conv to first stage's shortcut
  - `replace_stride_with_pooling`: Use pooling instead of strided conv

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.