### PR TITLE
Fix handling logical error when the data has invalid bbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ No changes to highlight.
 ## Other Changes:
 
 - Update pi 4b deployment benchmark by `@illian01` in [PR 492](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/492)
+- Clamp bbox for detection dataset loading by `@hglee98` in [PR 503](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/503#pullrequestreview-2247173939)
 
 # v1.0.0
 

--- a/src/netspresso_trainer/dataloaders/detection.py
+++ b/src/netspresso_trainer/dataloaders/detection.py
@@ -113,6 +113,10 @@ class DetectionCustomDataset(BaseCustomDataset):
         # right, bottom (rb)
         converted[..., 2] = w * (original[..., 0] + original[..., 2] / 2) + padw
         converted[..., 3] = h * (original[..., 1] + original[..., 3] / 2) + padh
+
+        # bbox clamping
+        np.clip(converted[..., 0::2], a_min=0, a_max=w, out=converted[..., 0::2])
+        np.clip(converted[..., 1::2], a_min=0, a_max=h, out=converted[..., 1::2])
         return converted
 
     def cache_dataset(self, sampler, distributed):


### PR DESCRIPTION
## Description

This PR aims to handle the issue mentioned on #502. It ensures that the resulting bounding boxes stay within the image boundaries.

Closes: #502

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add bbox clamp feature to `DetectionCustomDataset`

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.