### PR TITLE
[!HOTFIX] Add depthwise params to yolox-s benchmarking model config

### DIFF
--- a/config/benchmark_examples/detection-coco2017-yolox_s/model.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/model.yaml
@@ -13,6 +13,7 @@ model:
     backbone:
       name: cspdarknet
       params:
+        depthwise: False
         dep_mul: &dep_mul 0.33
         wid_mul: 0.5
         act_type: &act_type "silu"
@@ -20,11 +21,13 @@ model:
     neck:
       name: yolopafpn
       params:
+        depthwise: False
         dep_mul: *dep_mul
         act_type: *act_type
     head:
       name: anchor_free_decoupled_head
       params:
+        depthwise: False
         act_type: *act_type
   postprocessor: 
     params: 


### PR DESCRIPTION
## Description

This PR aims to fix the issue when we run benchmarking example of yolox-s because of the missing `depthwise` parameters in the model config.

Closes: None

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- [!HOTFIX] Add depthwise parameter to benchmarking example of yolox-s

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.