### PR TITLE
[fix] scaling the total_loss when performing backward propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ No changes to highlight.
 - Fix ViT token number in positional encoding for torch.fx compile step by `@illian01` in [PR 475](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/475)
 - Remove output typing of PIDNet by `@illian01` in [PR 477](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/477)
 - Update documentation by `@illian01` in [PR 483](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/483), [PR 485](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/485)
+- Minor refactorings by `hglee98` in [PR 513](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/513)
 
 # v0.2.2
 

--- a/src/netspresso_trainer/losses/builder.py
+++ b/src/netspresso_trainer/losses/builder.py
@@ -40,8 +40,7 @@ class LossFactory:
 
         for loss_element in self.conf_model.losses:
             criterion = loss_element.criterion
-            loss_config = {k: v for k, v in loss_element.items() if k not in [
-                'criterion', 'weight']}
+            loss_config = {k: v for k, v in loss_element.items() if k not in ['criterion', 'weight']}
             loss = LOSS_DICT[criterion](**loss_config, **kwargs)
 
             self.loss_func_dict.update({criterion: loss})
@@ -90,11 +89,9 @@ class LossFactory:
         for loss_key, loss_func in self.loss_func_dict.items():
             loss_val = loss_func(out, target)
             self.loss_val_per_epoch[phase][loss_key].update(loss_val.item())
-            self.total_loss_for_backward += loss_val * \
-                self.loss_weight_dict[loss_key]
+            self.total_loss_for_backward += loss_val * self.loss_weight_dict[loss_key]
 
-        self.loss_val_per_epoch[phase]['total'].update(
-            self.total_loss_for_backward.item())
+        self.loss_val_per_epoch[phase]['total'].update(self.total_loss_for_backward.item())
 
 
 def build_losses(conf_model, **kwargs):

--- a/src/netspresso_trainer/losses/builder.py
+++ b/src/netspresso_trainer/losses/builder.py
@@ -40,7 +40,8 @@ class LossFactory:
 
         for loss_element in self.conf_model.losses:
             criterion = loss_element.criterion
-            loss_config = {k: v for k, v in loss_element.items() if k not in ['criterion', 'weight']}
+            loss_config = {k: v for k, v in loss_element.items() if k not in [
+                'criterion', 'weight']}
             loss = LOSS_DICT[criterion](**loss_config, **kwargs)
 
             self.loss_func_dict.update({criterion: loss})
@@ -66,7 +67,7 @@ class LossFactory:
     def backward(self, grad_scaler: torch.cuda.amp.GradScaler):
         assert not self._dirty_backward
         self.total_loss_for_backward.requires_grad_(True)
-        grad_scaler.scale(self.total_loss_for_backward.mean()).backward()
+        grad_scaler.scale(self.total_loss_for_backward).backward()
         self._dirty_backward = True
 
     def result(self, phase='train'):
@@ -89,9 +90,11 @@ class LossFactory:
         for loss_key, loss_func in self.loss_func_dict.items():
             loss_val = loss_func(out, target)
             self.loss_val_per_epoch[phase][loss_key].update(loss_val.item())
-            self.total_loss_for_backward += loss_val * self.loss_weight_dict[loss_key]
+            self.total_loss_for_backward += loss_val * \
+                self.loss_weight_dict[loss_key]
 
-        self.loss_val_per_epoch[phase]['total'].update(self.total_loss_for_backward.item())
+        self.loss_val_per_epoch[phase]['total'].update(
+            self.total_loss_for_backward.item())
 
 
 def build_losses(conf_model, **kwargs):


### PR DESCRIPTION
## Description

This PR aims to fix the issue when performing backward propagation, GradScaler scales the mean value of total loss.

Closes: #512

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- change the total_loss.mean() to total_loss

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.