### PR TITLE
[fix] Make total_loss to be a scalar tensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ No changes to highlight.
 - Fix ViT token number in positional encoding for torch.fx compile step by `@illian01` in [PR 475](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/475)
 - Remove output typing of PIDNet by `@illian01` in [PR 477](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/477)
 - Update documentation by `@illian01` in [PR 483](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/483), [PR 485](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/485)
-- Minor refactorings by `hglee98` in [PR 513](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/513)
+- Minor refactorings by `hglee98` in [PR 513](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/513), [PR 518](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/518#pullrequestreview-2262154284)
 
 # v0.2.2
 

--- a/src/netspresso_trainer/losses/detection/rtdetr.py
+++ b/src/netspresso_trainer/losses/detection/rtdetr.py
@@ -282,35 +282,6 @@ class DETRLoss(nn.Module):
         losses['loss_giou'] = loss_giou.sum() / num_boxes
         return losses
 
-    # def loss_masks(self, outputs, targets, indices, num_boxes):
-    #     """Compute the losses related to the masks: the focal loss and the dice loss.
-    #        targets dicts must contain the key "masks" containing a tensor of dim [nb_target_boxes, h, w]
-    #     """
-    #     assert "pred_masks" in outputs
-
-    #     src_idx = self._get_src_permutation_idx(indices)
-    #     tgt_idx = self._get_tgt_permutation_idx(indices)
-    #     src_masks = outputs["pred_masks"]
-    #     src_masks = src_masks[src_idx]
-    #     masks = [t["masks"] for t in targets]
-    #     # TODO use valid to mask invalid areas due to padding in loss
-    #     target_masks, valid = nested_tensor_from_tensor_list(masks).decompose()
-    #     target_masks = target_masks.to(src_masks)
-    #     target_masks = target_masks[tgt_idx]
-
-    #     # upsample predictions to the target size
-    #     src_masks = interpolate(src_masks[:, None], size=target_masks.shape[-2:],
-    #                             mode="bilinear", align_corners=False)
-    #     src_masks = src_masks[:, 0].flatten(1)
-
-    #     target_masks = target_masks.flatten(1)
-    #     target_masks = target_masks.view(src_masks.shape)
-    #     losses = {
-    #         "loss_mask": sigmoid_focal_loss(src_masks, target_masks, num_boxes),
-    #         "loss_dice": dice_loss(src_masks, target_masks, num_boxes),
-    #     }
-    #     return losses
-
     def _get_src_permutation_idx(self, indices):
         # permute predictions following indices
         batch_idx = torch.cat([torch.full_like(src, i) for i, (src, _) in enumerate(indices)])
@@ -416,7 +387,7 @@ class DETRLoss(nn.Module):
                     l_dict = {k + f'_dn_{i}': v for k, v in l_dict.items()}
                     losses.update(l_dict)
 
-        total_loss = sum(losses.values())
+        total_loss = torch.cat(list(losses.values())).sum()
         return total_loss
 
     @staticmethod


### PR DESCRIPTION
## Description

This PR aims to fix the issue that the total loss of RT-DETR is not a scalar.

Closes: N/A

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- (Please write a description for this change.)

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.