### PR TITLE
[!HOTFIX] change concatenate to stack

### DIFF
--- a/src/netspresso_trainer/losses/detection/rtdetr.py
+++ b/src/netspresso_trainer/losses/detection/rtdetr.py
@@ -387,7 +387,7 @@ class DETRLoss(nn.Module):
                     l_dict = {k + f'_dn_{i}': v for k, v in l_dict.items()}
                     losses.update(l_dict)
 
-        total_loss = torch.cat(list(losses.values())).sum()
+        total_loss = torch.stack(list(losses.values())).sum()
         return total_loss
 
     @staticmethod


### PR DESCRIPTION
## Description

This PR aims to resolve the issue when the total_loss dict already has scalar tensors.

Closes: N/A

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- (Please write a description for this change.)

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.