### PR TITLE
Add `no_weight_decay` and `overwrite` option in optimizer config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features:
 
-No changes to highlight.
+- Add no_weight_decay and overwrite option in optimizer config by `@illian01` in [PR 534](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/534)
 
 ## Bug Fixes:
 

--- a/config/benchmark_examples/classification-imagenet1k-resnet18/training.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet18/training.yaml
@@ -9,6 +9,9 @@ training:
     momentum: 0.9
     weight_decay: 0.0001
     nesterov: False
+    no_bias_weight_decay: False
+    no_norm_weight_decay: False
+    overwrite: ~
   scheduler:
     name: step
     iters_per_phase: 30

--- a/config/benchmark_examples/classification-imagenet1k-resnet18/training.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet18/training.yaml
@@ -9,7 +9,7 @@ training:
     momentum: 0.9
     weight_decay: 0.0001
     nesterov: False
-    no_bias_weight_decay: False
+    no_bias_decay: False
     no_norm_weight_decay: False
     overwrite: ~
   scheduler:

--- a/config/benchmark_examples/classification-imagenet1k-resnet34/training.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet34/training.yaml
@@ -9,6 +9,9 @@ training:
     momentum: 0.9
     weight_decay: 0.0001
     nesterov: False
+    no_bias_weight_decay: False
+    no_norm_weight_decay: False
+    overwrite: ~
   scheduler:
     name: step
     iters_per_phase: 30

--- a/config/benchmark_examples/classification-imagenet1k-resnet34/training.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet34/training.yaml
@@ -9,7 +9,7 @@ training:
     momentum: 0.9
     weight_decay: 0.0001
     nesterov: False
-    no_bias_weight_decay: False
+    no_bias_decay: False
     no_norm_weight_decay: False
     overwrite: ~
   scheduler:

--- a/config/benchmark_examples/classification-imagenet1k-resnet50/training.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet50/training.yaml
@@ -9,7 +9,7 @@ training:
     momentum: 0.9
     weight_decay: 2e-5
     nesterov: False
-    no_bias_weight_decay: False
+    no_bias_decay: False
     no_norm_weight_decay: False
     overwrite: ~
   scheduler:

--- a/config/benchmark_examples/classification-imagenet1k-resnet50/training.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet50/training.yaml
@@ -9,6 +9,9 @@ training:
     momentum: 0.9
     weight_decay: 2e-5
     nesterov: False
+    no_bias_weight_decay: False
+    no_norm_weight_decay: False
+    overwrite: ~
   scheduler:
     name: cosine_no_sgdr
     warmup_epochs: 5

--- a/config/benchmark_examples/detection-coco2017-yolox_s/training.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/training.yaml
@@ -12,7 +12,7 @@ training:
     momentum: 0.9
     weight_decay: 0.0005 # No bias and norm decay
     nesterov: True
-    no_bias_weight_decay: True
+    no_bias_decay: True
     no_norm_weight_decay: True
     overwrite: ~
   scheduler:

--- a/config/benchmark_examples/detection-coco2017-yolox_s/training.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/training.yaml
@@ -12,6 +12,9 @@ training:
     momentum: 0.9
     weight_decay: 0.0005 # No bias and norm decay
     nesterov: True
+    no_bias_weight_decay: True
+    no_norm_weight_decay: True
+    overwrite: ~
   scheduler:
     name: cosine_no_sgdr
     warmup_epochs: 5

--- a/config/training.yaml
+++ b/config/training.yaml
@@ -8,8 +8,8 @@ training:
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
-    no_bias_weight_decay: True
-    no_norm_weight_decay: True
+    no_bias_weight_decay: False
+    no_norm_weight_decay: False
     overwrite: ~
   scheduler:
     name: cosine_no_sgdr

--- a/config/training.yaml
+++ b/config/training.yaml
@@ -8,9 +8,12 @@ training:
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
-    no_bias_weight_decay: False
+    no_bias_decay: False
     no_norm_weight_decay: False
-    overwrite: ~
+    overwrite:
+      - 
+        param_groups: 'backbone'
+        
   scheduler:
     name: cosine_no_sgdr
     warmup_epochs: 5

--- a/config/training.yaml
+++ b/config/training.yaml
@@ -10,10 +10,7 @@ training:
     weight_decay: 0.0005
     no_bias_decay: False
     no_norm_weight_decay: False
-    overwrite:
-      - 
-        param_groups: 'backbone'
-        
+    overwrite: ~
   scheduler:
     name: cosine_no_sgdr
     warmup_epochs: 5

--- a/config/training.yaml
+++ b/config/training.yaml
@@ -8,6 +8,9 @@ training:
     lr: 6e-5
     betas: [0.9, 0.999]
     weight_decay: 0.0005
+    no_bias_weight_decay: True
+    no_norm_weight_decay: True
+    overwrite: ~
   scheduler:
     name: cosine_no_sgdr
     warmup_epochs: 5

--- a/src/netspresso_trainer/optimizers/builder.py
+++ b/src/netspresso_trainer/optimizers/builder.py
@@ -43,8 +43,8 @@ def build_overwrited_dict(optimizer_conf):
             overwrited_config_dict[param_group].lr = module_overwrite_config.lr
         if hasattr(module_overwrite_config, 'weight_decay'):
             overwrited_config_dict[param_group].weight_decay = module_overwrite_config.weight_decay
-        if hasattr(module_overwrite_config, 'no_bias_weight_decay'):
-            overwrited_config_dict[param_group].no_bias_weight_decay = module_overwrite_config.no_bias_weight_decay
+        if hasattr(module_overwrite_config, 'no_bias_decay'):
+            overwrited_config_dict[param_group].no_bias_decay = module_overwrite_config.no_bias_decay
         if hasattr(module_overwrite_config, 'no_norm_weight_decay'):
             overwrited_config_dict[param_group].no_norm_weight_decay = module_overwrite_config.no_norm_weight_decay
 
@@ -55,7 +55,7 @@ def separate_no_weights_decay(params: set, module_config: DictConfig):
     bias_params = set(filter(lambda s: 'bias' in s, params))
     norm_params = set(filter(lambda s: 'norm.weight' in s, params))
     no_decay_params = set()
-    if module_config.no_bias_weight_decay:
+    if module_config.no_bias_decay:
         no_decay_params |= bias_params
         params -= bias_params
     if module_config.no_norm_weight_decay:
@@ -93,7 +93,7 @@ def split_param_groups(model, overwrited_config_dict):
     param_opt_configs = []
     for param_group_key, module_overwrite_config in overwrited_config_dict.items():
         # Remove unnecessary fields
-        del module_overwrite_config['no_bias_weight_decay']
+        del module_overwrite_config['no_bias_decay']
         del module_overwrite_config['no_norm_weight_decay']
 
         params, no_decay_params = param_set_dict[param_group_key]

--- a/src/netspresso_trainer/optimizers/builder.py
+++ b/src/netspresso_trainer/optimizers/builder.py
@@ -18,18 +18,124 @@ from typing import Literal
 
 import torch.nn as nn
 from omegaconf import DictConfig
+from loguru import logger
 
 from .registry import OPTIMIZER_DICT
 
 
+def build_overwrited_dict(optimizer_conf):
+    tmp_optimizer_conf = optimizer_conf.copy()
+    del tmp_optimizer_conf['overwrite'] # Remove unnecessary field
+    overwrited_config_dict = {
+        'backbone': tmp_optimizer_conf.copy(),
+        'neck': tmp_optimizer_conf.copy(),
+        'head': tmp_optimizer_conf.copy(),
+    }
+
+    overwrite_config = optimizer_conf.overwrite
+    for module_overwrite_config in overwrite_config:
+        if not hasattr(module_overwrite_config, 'param_group'):
+            raise ValueError(f"Overwrite config must have 'param_group' field: {module_overwrite_config}")
+
+        param_group = module_overwrite_config.param_group
+
+        if hasattr(module_overwrite_config, 'lr'):
+            overwrited_config_dict[param_group].lr = module_overwrite_config.lr
+        if hasattr(module_overwrite_config, 'weight_decay'):
+            overwrited_config_dict[param_group].weight_decay = module_overwrite_config.weight_decay
+        if hasattr(module_overwrite_config, 'no_bias_weight_decay'):
+            overwrited_config_dict[param_group].no_bias_weight_decay = module_overwrite_config.no_bias_weight_decay
+        if hasattr(module_overwrite_config, 'no_norm_weight_decay'):
+            overwrited_config_dict[param_group].no_norm_weight_decay = module_overwrite_config.no_norm_weight_decay
+
+    return overwrited_config_dict
+
+
+def split_param_groups(model, overwrited_config_dict):
+    backbone_params = set()
+    neck_params = set()
+    head_params = set()
+
+    # Separate parameters by module
+    named_params_dict = dict(model.named_parameters())
+    for k in named_params_dict.keys():
+        if k.startswith('backbone'):
+            backbone_params.add(k)
+        elif k.startswith('neck'):
+            neck_params.add(k)
+        elif k.startswith('head'):
+            head_params.add(k)
+        else:
+            raise ValueError(f"Unknown parameter group: {k}") # Only for NetsPresso Trainer defined model
+
+    # Separate parameters by weight, bias, and norm
+    def separate_no_weights_decay(params: set, module_config: DictConfig):
+        bias_params = set(filter(lambda s: 'bias' in s, params))
+        norm_params = set(filter(lambda s: 'norm.weight' in s, params))
+        no_decay_params = set()
+        if module_config.no_bias_weight_decay:
+            no_decay_params |= bias_params
+            params -= bias_params
+        if module_config.no_norm_weight_decay:
+            no_decay_params |= norm_params
+            params -= norm_params
+        return params, no_decay_params
+
+    backbone_params = separate_no_weights_decay(backbone_params, overwrited_config_dict['backbone'])
+    neck_params = separate_no_weights_decay(neck_params, overwrited_config_dict['neck'])
+    head_params = separate_no_weights_decay(head_params, overwrited_config_dict['head'])
+
+    param_set_dict = {'backbone': backbone_params, 'neck': neck_params, 'head': head_params}
+
+    # Build param_groups and param_configs
+    param_groups = []
+    param_opt_configs = []
+    for param_group_key, module_overwrite_config in overwrited_config_dict.items():
+        # Remove unnecessary fields
+        del module_overwrite_config['no_bias_weight_decay']
+        del module_overwrite_config['no_norm_weight_decay']
+
+        params, no_decay_params = param_set_dict[param_group_key]
+
+        module_overwrite_config.group_name = param_group_key + '_group'
+        if len(params) != 0: # Skip if no parameters, e.g. no neck in the model
+            param_groups.append([named_params_dict[k] for k in params]) # Convert from key to parameters
+            param_opt_configs.append(module_overwrite_config.copy())
+
+        module_overwrite_config.group_name = param_group_key + '_no_decay_group'
+        module_overwrite_config.weight_decay = 0.0
+        if len(no_decay_params) != 0: # Skip if no parameters, e.g. use weight decay for all parameters
+            param_groups.append([named_params_dict[k] for k in no_decay_params])
+            param_opt_configs.append(module_overwrite_config.copy())
+
+    return param_groups, param_opt_configs
+
 def build_optimizer(
-    model_or_params,
+    model,
+    single_task_model: bool,
     optimizer_conf: DictConfig,
 ):
-    parameters = model_or_params.parameters() if isinstance(model_or_params, nn.Module) else model_or_params
+    no_dist_model = model.module if hasattr(model, 'module') else model
 
     opt_name: Literal['sgd', 'adam', 'adamw', 'adamax', 'adadelta', 'adagrad', 'rmsprop'] = optimizer_conf.name.lower()
     assert opt_name in OPTIMIZER_DICT
 
-    optimizer = OPTIMIZER_DICT[opt_name](parameters, optimizer_conf)
+    overwrite_config = optimizer_conf.overwrite
+    if overwrite_config:
+        assert not single_task_model, "Overwrite config only for non single task model"
+        overwrited_config_dict = build_overwrited_dict(optimizer_conf)
+        param_groups, param_opt_configs = split_param_groups(no_dist_model, overwrited_config_dict)
+
+        base_param_group = param_groups.pop(0)
+        base_opt_config = param_opt_configs.pop(0)
+        optimizer = OPTIMIZER_DICT[opt_name](base_param_group, base_opt_config)
+        optimizer.param_groups[0]['group_name'] = base_opt_config.group_name # Add group name manually
+
+        for param_group, opt_config in zip(param_groups, param_opt_configs):
+            del opt_config['name'] # Remove unnecessary field
+            optimizer.add_param_group({'params': param_group, **opt_config})
+
+    else:
+        optimizer = OPTIMIZER_DICT[opt_name](no_dist_model.parameters(), optimizer_conf)
+
     return optimizer

--- a/src/netspresso_trainer/optimizers/builder.py
+++ b/src/netspresso_trainer/optimizers/builder.py
@@ -17,8 +17,8 @@
 from typing import Literal
 
 import torch.nn as nn
-from omegaconf import DictConfig
 from loguru import logger
+from omegaconf import DictConfig
 
 from .registry import OPTIMIZER_DICT
 
@@ -71,7 +71,7 @@ def split_param_groups(model, overwrited_config_dict):
 
     # Separate parameters by module
     named_params_dict = dict(model.named_parameters())
-    for k in named_params_dict.keys():
+    for k in named_params_dict:
         if k.startswith('backbone'):
             backbone_params.add(k)
         elif k.startswith('neck'):

--- a/src/netspresso_trainer/pipelines/builder.py
+++ b/src/netspresso_trainer/pipelines/builder.py
@@ -88,7 +88,7 @@ def build_pipeline(
         eval_dataloader: DataLoader = dataloaders['valid']
 
         # Build optimizer and scheduler
-        optimizer = build_optimizer(model, optimizer_conf=conf.training.optimizer)
+        optimizer = build_optimizer(model, single_task_model=conf.model.single_task_model, optimizer_conf=conf.training.optimizer)
         scheduler, _ = build_scheduler(optimizer, conf.training)
         optimizer, scheduler, start_epoch = load_optimizer_checkpoint(conf, optimizer, scheduler)
 


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #528 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add `no_weight_decay` and `overwrite` option in optimizer config
- `no_bias_weight_decay`: Set `weight_decay` to `0.0` for bias parameters
- `no_norm_weight_decay`: Set `weight_decay` to `0.0` for normalization weight parameters
- `overwrite`: Overwrite optimizer configs model-wisely
  - Only for `lr`, `weight_decay`, `no_bias_weight_decay`, `no_norm_weight_decay`

Example:
```
  optimizer:
    name: adamw
    lr: 6e-5
    betas: [0.9, 0.999]
    weight_decay: 0.0005
    no_bias_decay: False
    no_norm_weight_decay: False
    overwrite:
      - 
        param_group: 'backbone'
        lr: 6e-4
      -
        param_group: 'neck'
        no_bias_decay: True
        no_norm_weight_decay: True
      -
        param_group: 'head'
        weight_decay: 0.0001
```

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.