### PR TITLE
Fix RandomCrop and segmentation dataset getitem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix bug in RandomCrop and segmentation dataset getitem by `@illian01` in [PR 535](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/535)
 
 ## Breaking Changes:
 

--- a/docs/components/augmentation/transforms.md
+++ b/docs/components/augmentation/transforms.md
@@ -259,7 +259,7 @@ Crop the given image at a random location. This augmentation follows the [Random
 |---|---|
 | `name` | (str) Name must be "randomcrop" to use `RandomCrop` transform. |
 | `size` | (int or list) Desired output size of the crop. If size is an int, a square crop (size, size) is made. If provided a list of length 1, it will be interpreted as (size[0], size[0]). If a list of length 2 is provided, a square crop (size[0], size[1]) is made. |
-
+| `fill` | (int or list) If a single int is provided this is used to fill pixels with constant value. If a list of length 3, it is used to fill R, G, B channels respectively.
 <details>
   <summary>RandomCrop example</summary>
   
@@ -269,6 +269,7 @@ Crop the given image at a random location. This augmentation follows the [Random
       - 
         name: randomcrop
         size: 256
+        fill: 114
   ```
 </details>
 

--- a/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
+++ b/src/netspresso_trainer/dataloaders/augmentation/custom/image_proc.py
@@ -307,6 +307,7 @@ class RandomCrop:
     def __init__(
         self,
         size: Union[int, List],
+        fill: int,
     ):
 
         if not isinstance(size, (int, Sequence)):
@@ -315,7 +316,7 @@ class RandomCrop:
             raise ValueError("If size is a sequence, it should have 1 or 2 values")
         self.size_h = size[0] if isinstance(size, Sequence) else size
         self.size_w = size[1] if isinstance(size, Sequence) else size
-        self.image_pad_if_needed = Pad((self.size_h, self.size_w))
+        self.image_pad_if_needed = Pad((self.size_h, self.size_w), fill=fill)
 
     def _crop_bbox(self, bbox, i, j, h, w):
         area_original = (bbox[..., 2] - bbox[..., 0]) * (bbox[..., 3] - bbox[..., 1])
@@ -330,7 +331,7 @@ class RandomCrop:
         return bbox
 
     def __call__(self, image, label=None, mask=None, bbox=None, keypoint=None, dataset=None):
-        image, mask, bbox = self.image_pad_if_needed(image=image, mask=mask, bbox=bbox)
+        image, _, mask, bbox, _ = self.image_pad_if_needed(image=image, mask=mask, bbox=bbox)
         i, j, h, w = T.RandomCrop.get_params(image, (self.size_h, self.size_w))
         image = F.crop(image, i, j, h, w)
         if mask is not None:

--- a/src/netspresso_trainer/dataloaders/segmentation.py
+++ b/src/netspresso_trainer/dataloaders/segmentation.py
@@ -209,10 +209,10 @@ class SegmentationCustomDataset(BaseCustomDataset):
 
         if 'pidnet' in self.model_name:
             edge = generate_edge(np.array(mask))
-            out = self.transform(image=img, mask=mask, edge=edge)
+            out = self.transform(image=img, mask=mask, edge=edge, dataset=self)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'edges': out['edge'].float()})
         else:
-            out = self.transform(image=img, mask=mask)
+            out = self.transform(image=img, mask=mask, dataset=self)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask']})
 
         if self._split in ['train', 'training']:
@@ -297,10 +297,10 @@ class SegmentationHFDataset(BaseHFDataset):
 
         if 'pidnet' in self.model_name:
             edge = generate_edge(np.array(label))
-            out = self.transform(image=img, mask=mask, edge=edge)
+            out = self.transform(image=img, mask=mask, edge=edge, dataset=self)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'edges': out['edge'].float(), 'name': img_name})
         else:
-            out = self.transform(image=img, mask=mask)
+            out = self.transform(image=img, mask=mask, dataset=self)
             outputs.update({'pixel_values': out['image'], 'labels': out['mask'], 'name': img_name})
 
         outputs.update({'indices': index})


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #(issue number)

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Fix bug in RandomCrop and segmentation dataset getitem

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.