### PR TITLE
Fix no 'deploy' attribute error in fx model train phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fix bug in RandomCrop and segmentation dataset getitem by `@illian01` in [PR 535](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/535)
 - Handle unexpected error during training rt-detr by `@hglee98` in [PR 530](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/530)
+- Fix no 'deploy' attribute error in fx model train phase by `@illian01` in [PR 543](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/543)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -238,7 +238,8 @@ class TrainingPipeline(BasePipeline):
             model = self.model_ema.ema_model
         else:
             model = self.model.module if hasattr(self.model, 'module') else self.model
-        model.deploy()
+        if hasattr(model, 'deploy'):
+            model.deploy()
         save_dtype = model.save_dtype
 
         if save_dtype == torch.float16:
@@ -276,7 +277,9 @@ class TrainingPipeline(BasePipeline):
 
         model = self.model.module if hasattr(self.model, 'module') else self.model
         save_dtype = model.save_dtype
-        best_model_to_save = copy.deepcopy(model).deploy()
+        best_model_to_save = copy.deepcopy(model)
+        if hasattr(best_model_to_save, 'deploy'):
+            best_model_to_save.deploy()
 
         if self.is_graphmodule_training:
             best_model_to_save.load_state_dict(load_checkpoint(best_checkpoint_path.with_suffix('.pt')).state_dict())


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #542 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Check 'deploy' attribute before calling it

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.