### PR TITLE
[feat] Save best model by criterion selected by users

### DIFF
--- a/config/benchmark_examples/classification-imagenet1k-resnet18/logging.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet18/logging.yaml
@@ -4,9 +4,11 @@ logging:
   tensorboard: true
   image: true
   stdout: true
-  save_optimizer_state: true
-  save_best_only: false
-  sample_input_size: [224, 224] # Used for flops and onnx export
-  onnx_export_opset: 13 # Recommend in range [13, 17]
-  validation_epoch: &validation_epoch 5
-  save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.
+  model_save_options:
+    save_optimizer_state: true
+    save_best_only: false
+    save_criterion: loss # metric
+    sample_input_size: [224, 224] # Used for flops and onnx export
+    onnx_export_opset: 13 # Recommend in range [13, 17]
+    validation_epoch: &validation_epoch 5
+    save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.

--- a/config/benchmark_examples/classification-imagenet1k-resnet34/logging.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet34/logging.yaml
@@ -4,9 +4,11 @@ logging:
   tensorboard: true
   image: true
   stdout: true
-  save_optimizer_state: true
-  save_best_only: false
-  sample_input_size: [224, 224] # Used for flops and onnx export
-  onnx_export_opset: 13 # Recommend in range [13, 17]
-  validation_epoch: &validation_epoch 5
-  save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.
+  model_save_options:
+    save_optimizer_state: true
+    save_best_only: false
+    save_criterion: loss # metric
+    sample_input_size: [224, 224] # Used for flops and onnx export
+    onnx_export_opset: 13 # Recommend in range [13, 17]
+    validation_epoch: &validation_epoch 5
+    save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.

--- a/config/benchmark_examples/classification-imagenet1k-resnet50/logging.yaml
+++ b/config/benchmark_examples/classification-imagenet1k-resnet50/logging.yaml
@@ -4,9 +4,11 @@ logging:
   tensorboard: true
   image: true
   stdout: true
-  save_optimizer_state: true
-  save_best_only: false
-  sample_input_size: [224, 224] # Used for flops and onnx export
-  onnx_export_opset: 13 # Recommend in range [13, 17]
-  validation_epoch: &validation_epoch 10
-  save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.
+  model_save_options:
+    save_optimizer_state: true
+    save_best_only: false
+    save_criterion: loss # metric
+    sample_input_size: [224, 224] # Used for flops and onnx export
+    onnx_export_opset: 13 # Recommend in range [13, 17]
+    validation_epoch: &validation_epoch 10
+    save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.

--- a/config/benchmark_examples/detection-coco2017-yolox_s/logging.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/logging.yaml
@@ -4,9 +4,11 @@ logging:
   tensorboard: true
   image: true
   stdout: true
-  save_optimizer_state: true
-  save_best_only: false
-  sample_input_size: [640, 640] # Used for flops and onnx export
-  onnx_export_opset: 13 # Recommend in range [13, 17]
-  validation_epoch: &validation_epoch 10
-  save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.
+  model_save_options:
+    save_optimizer_state: true
+    save_best_only: false
+    save_criterion: loss # metric
+    sample_input_size: [640, 640] # Used for flops and onnx export
+    onnx_export_opset: 13 # Recommend in range [13, 17]
+    validation_epoch: &validation_epoch 10
+    save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.

--- a/config/logging.yaml
+++ b/config/logging.yaml
@@ -4,9 +4,11 @@ logging:
   tensorboard: true
   image: true
   stdout: true
-  save_optimizer_state: true
-  save_best_only: false
-  sample_input_size: [512, 512] # Used for flops and onnx export
-  onnx_export_opset: 13 # Recommend in range [13, 17]
-  validation_epoch: &validation_epoch 10
-  save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.
+  model_save_options:
+    save_optimizer_state: true
+    save_best_only: false
+    save_criterion: loss # metric
+    sample_input_size: [512, 512] # Used for flops and onnx export
+    onnx_export_opset: 13 # Recommend in range [13, 17]
+    validation_epoch: &validation_epoch 10
+    save_checkpoint_epoch: *validation_epoch  # Multiplier of `validation_epoch`.

--- a/src/netspresso_trainer/loggers/base.py
+++ b/src/netspresso_trainer/loggers/base.py
@@ -58,7 +58,7 @@ class TrainingLogger():
         self.use_tensorboard: bool = self.conf.logging.tensorboard
         self.use_imagesaver: bool = self.conf.logging.image
         self.use_stdout: bool = self.conf.logging.stdout
-        self._save_best_only: bool = self.conf.logging.save_best_only
+        self._save_best_only: bool = self.conf.logging.model_save_options.save_best_only
 
         self.loggers = []
         if self.use_imagesaver:

--- a/src/netspresso_trainer/pipelines/base.py
+++ b/src/netspresso_trainer/pipelines/base.py
@@ -48,7 +48,7 @@ class BasePipeline(ABC):
 
     @property
     def sample_input(self):
-        return torch.randn((1, 3, self.conf.logging.sample_input_size[0], self.conf.logging.sample_input_size[1]))
+        return torch.randn((1, 3, self.conf.logging.model_save_options.sample_input_size[0], self.conf.logging.model_save_options.sample_input_size[1]))
 
     def log_results(
         self,


### PR DESCRIPTION
## Description

This PR introduces a new feature that allows users to select the criterion (loss or metric) for saving the best model checkpoint during training. Previously, the best model was saved based solely on validation loss.

Related to #554 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Implement user-selectable criterion for best model checkpoint in `logging.yaml`
- Update model saving logic to use the chosen criterion

TODOs
- [ ] Add detailed selectable metric option criterions (e.g., mAP50, precision, recall, PCK, etc.)

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.