### PR TITLE
Add feature to save last model artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add RandomResize2 by `@illian01` in [PR 550](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/550)
 - Add confidence score on detection visualization by `@hglee98` in [PR 552](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/552)
-- Add save_best_only option for saving model by `@hglee98` in [PR 555](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/555)
+- Add save_best_only option for saving model by `@hglee98` in [PR 555](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/555), [PR 567](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/567)
 - Add option to select best model saving criterion by `@hglee98` in [PR 557](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/557)
 - Add MultiStepLR scheduler by `@hglee98` in [PR 559](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/559)
 - Add class-wise metric analysis option by `@illian01` in [PR 568](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/568)

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -273,15 +273,11 @@ class TrainingPipeline(BasePipeline):
         self.training_history.update({epoch: summary_record})
 
     def save_checkpoint(self, epoch: int):
-        save_best_only = self.conf.logging.model_save_options.save_best_only
-
-        if save_best_only and epoch != self.get_best_epoch():
-            return
-
         if self.model_ema:
             model = self.model_ema.ema_model
         else:
             model = self.model.module if hasattr(self.model, 'module') else self.model
+
         if hasattr(model, 'deploy'):
             model.deploy()
 
@@ -290,8 +286,17 @@ class TrainingPipeline(BasePipeline):
             model = copy.deepcopy(model).type(save_dtype)
 
         logging_dir = self.logger.result_dir
-        model_name_tag = "best" if save_best_only else f"epoch_{epoch}"
-        model_path =  Path(logging_dir) / f"{self.task}_{self.model_name}_{model_name_tag}.ext"
+        save_best_only = self.conf.logging.model_save_options.save_best_only
+
+        if save_best_only:
+            if epoch == self.get_best_epoch():
+                self._save_model(model=model, epoch=epoch, model_name_tag="best", logging_dir=logging_dir)
+            self._save_model(model=model, epoch=epoch, model_name_tag="last", logging_dir=logging_dir)
+        else:
+            self._save_model(model=model, epoch=epoch, model_name_tag=f"epoch_{epoch}", logging_dir=logging_dir)
+
+    def _save_model(self, model, epoch: int, model_name_tag: str, logging_dir: Path):
+        model_path = Path(logging_dir) / f"{self.task}_{self.model_name}_{model_name_tag}.ext"
         optimizer_path = Path(logging_dir) / f"{self.task}_{self.model_name}_{model_name_tag}_optimizer.pth"
 
         if self.conf.logging.model_save_options.save_optimizer_state:
@@ -305,6 +310,7 @@ class TrainingPipeline(BasePipeline):
             torch.save(model, model_path.with_suffix(".pt"))
             logger.debug(f"PyTorch FX model saved at {str(model_path.with_suffix('.pt'))}")
             return
+
         pytorch_model_state_dict_path = model_path.with_suffix(".safetensors")
         save_checkpoint(model.state_dict(), pytorch_model_state_dict_path)
         logger.debug(f"PyTorch model saved at {str(pytorch_model_state_dict_path)}")


### PR DESCRIPTION
## Description

This PR aims to propose a feature to save the last model artifacts to enable users continue the training process.

Related to #554 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add save_last feature to save_checkpoint
- refactor saving model process

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.