### PR TITLE
Add tabulating step for metric standard outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add ReLU6 by `@hglee98` in [PR 566](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/566)
 - Add TFLite model evaluation feature by `@hglee98` in [PR 563](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/563)
 - Add YOLO-Fastest-v2 by `@hglee98` in [PR 548](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/548)
+- Add tabulating step for metric standard outputs by `@illian01` in [PR 570](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/570)
 
 ## Bug Fixes:
 

--- a/src/netspresso_trainer/loggers/stdout.py
+++ b/src/netspresso_trainer/loggers/stdout.py
@@ -59,7 +59,7 @@ class StdOutLogger:
                 rows += [class_info.split('_', 1) for class_info in list(metrics[headers[-1]]['classwise'].keys())]
             rows += [['-', 'Mean', ]]
 
-            for metric_name, score_dict in metrics.items():
+            for _metric_name, score_dict in metrics.items():
                 if 'classwise' in score_dict: # If classwise analysis is activated
                     for cls_num, item in enumerate(score_dict['classwise']):
                         rows[cls_num].append(score_dict['classwise'][item])

--- a/src/netspresso_trainer/loggers/stdout.py
+++ b/src/netspresso_trainer/loggers/stdout.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from loguru import logger
+from tabulate import tabulate
 
 LOG_FILENAME = "result.log"
 
@@ -49,6 +50,20 @@ class StdOutLogger:
         if losses is not None:
             logger.info(f"{prefix} loss: {losses['total']:.7f}")
         if metrics is not None:
-            if isinstance(metrics[list(metrics.keys())[0]], dict): # TODO: Print classwise metrics in a better way
-                pass
-            logger.info(f"{prefix} metric: {[(name, value) for name, value in metrics.items()]}")
+            metric_std_log = f'{prefix} metric:\n'
+
+            headers = ['Class number', 'Class name', *list(metrics.keys())]
+
+            rows = []
+            if 'classwise' in metrics[headers[-1]]: # If classwise analysis is activated
+                rows += [class_info.split('_', 1) for class_info in list(metrics[headers[-1]]['classwise'].keys())]
+            rows += [['-', 'Mean', ]]
+
+            for metric_name, score_dict in metrics.items():
+                if 'classwise' in score_dict: # If classwise analysis is activated
+                    for cls_num, item in enumerate(score_dict['classwise']):
+                        rows[cls_num].append(score_dict['classwise'][item])
+                rows[-1].append(score_dict['mean'])
+
+            metric_std_log += tabulate(rows, headers=headers, tablefmt='grid', numalign='left', stralign='left')
+            logger.info(metric_std_log) # tabulaate is already contained as pandas dependency

--- a/src/netspresso_trainer/pipelines/evaluation.py
+++ b/src/netspresso_trainer/pipelines/evaluation.py
@@ -106,7 +106,7 @@ class EvaluationPipeline(BasePipeline):
                 tmp_metrics[metric_name] = {'mean': metric['mean'], 'classwise': {}}
                 for cls_num, score in metric['classwise'].items():
                     cls_name = self.logger.class_map[cls_num] if cls_num in self.logger.class_map else 'mean'
-                    tmp_metrics[metric_name]['classwise'][cls_name] = score
+                    tmp_metrics[metric_name]['classwise'][f'{cls_num}_{cls_name}'] = score
             metrics = tmp_metrics
 
         self.log_results(

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -274,7 +274,7 @@ class TrainingPipeline(BasePipeline):
                     tmp_metrics[metric_name] = {'mean': metric['mean'], 'classwise': {}}
                     for cls_num, score in metric['classwise'].items():
                         cls_name = self.logger.class_map[cls_num] if cls_num in self.logger.class_map else 'mean'
-                        tmp_metrics[metric_name]['classwise'][cls_name] = score
+                        tmp_metrics[metric_name]['classwise'][f'{cls_num}_{cls_name}'] = score
                 valid_metrics = tmp_metrics
 
             self.log_results(prefix='validation', epoch=epoch, samples=valid_samples, losses=valid_losses, metrics=valid_metrics)


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #569

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Tabulate metric values for standard output

Example: Evaluation yolox-s on coco

```
2024-10-28 07:55:29.990 | INFO     | netspresso_trainer.loggers.stdout:__call__:69 - evaluation metric:
+----------------+----------------+----------+-----------+------------+
| Class number   | Class name     | mAP50    | mAP75     | mAP50_95   |
+================+================+==========+===========+============+
| 0              | person         | 0.765279 | 0.564052  | 0.523979   |
+----------------+----------------+----------+-----------+------------+
| 1              | bicycle        | 0.527224 | 0.272457  | 0.297327   |
+----------------+----------------+----------+-----------+------------+
| 2              | car            | 0.650849 | 0.444577  | 0.420054   |
+----------------+----------------+----------+-----------+------------+
| 3              | motorcycle     | 0.702981 | 0.451243  | 0.437938   |
+----------------+----------------+----------+-----------+------------+
| 4              | airplane       | 0.86822  | 0.701507  | 0.654229   |
+----------------+----------------+----------+-----------+------------+
| 5              | bus            | 0.796051 | 0.718839  | 0.65102    |
+----------------+----------------+----------+-----------+------------+
| 6              | train          | 0.873511 | 0.748056  | 0.674374   |
+----------------+----------------+----------+-----------+------------+
| 7              | truck          | 0.542523 | 0.360316  | 0.35357    |
+----------------+----------------+----------+-----------+------------+
| 8              | boat           | 0.493443 | 0.234108  | 0.252203   |
+----------------+----------------+----------+-----------+------------+
| 9              | traffic light  | 0.533613 | 0.267546  | 0.280209   |
+----------------+----------------+----------+-----------+------------+
| 10             | fire hydrant   | 0.853238 | 0.765233  | 0.667869   |
+----------------+----------------+----------+-----------+------------+
| 11             | stop sign      | 0.785296 | 0.759273  | 0.684154   |
+----------------+----------------+----------+-----------+------------+
| 12             | parking meter  | 0.627786 | 0.534048  | 0.476132   |
+----------------+----------------+----------+-----------+------------+
| 13             | bench          | 0.373579 | 0.244323  | 0.241228   |
+----------------+----------------+----------+-----------+------------+
| 14             | bird           | 0.491484 | 0.321336  | 0.307394   |
+----------------+----------------+----------+-----------+------------+
| 15             | cat            | 0.866864 | 0.731902  | 0.655508   |
+----------------+----------------+----------+-----------+------------+
| 16             | dog            | 0.74836  | 0.692233  | 0.616047   |
+----------------+----------------+----------+-----------+------------+
| 17             | horse          | 0.808286 | 0.674304  | 0.609392   |
+----------------+----------------+----------+-----------+------------+
| 18             | sheep          | 0.731727 | 0.532254  | 0.490205   |
+----------------+----------------+----------+-----------+------------+
| 19             | cow            | 0.759255 | 0.604092  | 0.538784   |
+----------------+----------------+----------+-----------+------------+
| 20             | elephant       | 0.842588 | 0.680686  | 0.640336   |
+----------------+----------------+----------+-----------+------------+
| 21             | bear           | 0.890698 | 0.849788  | 0.743217   |
+----------------+----------------+----------+-----------+------------+
| 22             | zebra          | 0.895731 | 0.729033  | 0.669546   |
+----------------+----------------+----------+-----------+------------+
| 23             | giraffe        | 0.908695 | 0.774381  | 0.699976   |
+----------------+----------------+----------+-----------+------------+
| 24             | backpack       | 0.254363 | 0.126656  | 0.140023   |
+----------------+----------------+----------+-----------+------------+
| 25             | umbrella       | 0.61816  | 0.417664  | 0.398118   |
+----------------+----------------+----------+-----------+------------+
| 26             | handbag        | 0.239426 | 0.136685  | 0.131559   |
+----------------+----------------+----------+-----------+------------+
| 27             | tie            | 0.534501 | 0.324955  | 0.304126   |
+----------------+----------------+----------+-----------+------------+
| 28             | suitcase       | 0.574082 | 0.428447  | 0.394931   |
+----------------+----------------+----------+-----------+------------+
| 29             | frisbee        | 0.836215 | 0.751656  | 0.654145   |
+----------------+----------------+----------+-----------+------------+
| 30             | skis           | 0.486975 | 0.224323  | 0.239449   |
+----------------+----------------+----------+-----------+------------+
| 31             | snowboard      | 0.460609 | 0.377384  | 0.322166   |
+----------------+----------------+----------+-----------+------------+
| 32             | sports ball    | 0.648949 | 0.554997  | 0.472812   |
+----------------+----------------+----------+-----------+------------+
| 33             | kite           | 0.621969 | 0.496661  | 0.424297   |
+----------------+----------------+----------+-----------+------------+
| 34             | baseball bat   | 0.575216 | 0.287365  | 0.320054   |
+----------------+----------------+----------+-----------+------------+
| 35             | baseball glove | 0.620927 | 0.411663  | 0.367307   |
+----------------+----------------+----------+-----------+------------+
| 36             | skateboard     | 0.764387 | 0.544787  | 0.522637   |
+----------------+----------------+----------+-----------+------------+
| 37             | surfboard      | 0.583728 | 0.377782  | 0.357938   |
+----------------+----------------+----------+-----------+------------+
| 38             | tennis racket  | 0.780268 | 0.471799  | 0.473664   |
+----------------+----------------+----------+-----------+------------+
| 39             | bottle         | 0.549536 | 0.403968  | 0.361935   |
+----------------+----------------+----------+-----------+------------+
| 40             | wine glass     | 0.540029 | 0.330343  | 0.332671   |
+----------------+----------------+----------+-----------+------------+
| 41             | cup            | 0.557197 | 0.434054  | 0.390214   |
+----------------+----------------+----------+-----------+------------+
| 42             | fork           | 0.491114 | 0.341766  | 0.325791   |
+----------------+----------------+----------+-----------+------------+
| 43             | knife          | 0.29742  | 0.173013  | 0.169948   |
+----------------+----------------+----------+-----------+------------+
| 44             | spoon          | 0.2487   | 0.153224  | 0.144024   |
+----------------+----------------+----------+-----------+------------+
| 45             | bowl           | 0.572064 | 0.471629  | 0.4212     |
+----------------+----------------+----------+-----------+------------+
| 46             | banana         | 0.376498 | 0.223809  | 0.220529   |
+----------------+----------------+----------+-----------+------------+
| 47             | apple          | 0.24339  | 0.187055  | 0.163011   |
+----------------+----------------+----------+-----------+------------+
| 48             | sandwich       | 0.481782 | 0.363394  | 0.332984   |
+----------------+----------------+----------+-----------+------------+
| 49             | orange         | 0.401085 | 0.336375  | 0.303277   |
+----------------+----------------+----------+-----------+------------+
| 50             | broccoli       | 0.397242 | 0.200044  | 0.214675   |
+----------------+----------------+----------+-----------+------------+
| 51             | carrot         | 0.311073 | 0.190991  | 0.188722   |
+----------------+----------------+----------+-----------+------------+
| 52             | hot dog        | 0.508058 | 0.355436  | 0.318714   |
+----------------+----------------+----------+-----------+------------+
| 53             | pizza          | 0.718101 | 0.561176  | 0.519409   |
+----------------+----------------+----------+-----------+------------+
| 54             | donut          | 0.551792 | 0.480393  | 0.422405   |
+----------------+----------------+----------+-----------+------------+
| 55             | cake           | 0.528756 | 0.344263  | 0.33204    |
+----------------+----------------+----------+-----------+------------+
| 56             | chair          | 0.451045 | 0.297908  | 0.281948   |
+----------------+----------------+----------+-----------+------------+
| 57             | couch          | 0.629286 | 0.470778  | 0.460869   |
+----------------+----------------+----------+-----------+------------+
| 58             | potted plant   | 0.450588 | 0.241169  | 0.249039   |
+----------------+----------------+----------+-----------+------------+
| 59             | bed            | 0.617182 | 0.453414  | 0.428758   |
+----------------+----------------+----------+-----------+------------+
| 60             | dining table   | 0.446655 | 0.308982  | 0.29901    |
+----------------+----------------+----------+-----------+------------+
| 61             | toilet         | 0.783533 | 0.696131  | 0.625435   |
+----------------+----------------+----------+-----------+------------+
| 62             | tv             | 0.773737 | 0.686243  | 0.584381   |
+----------------+----------------+----------+-----------+------------+
| 63             | laptop         | 0.749193 | 0.661332  | 0.596625   |
+----------------+----------------+----------+-----------+------------+
| 64             | mouse          | 0.766127 | 0.6601    | 0.566543   |
+----------------+----------------+----------+-----------+------------+
| 65             | remote         | 0.436678 | 0.238397  | 0.247342   |
+----------------+----------------+----------+-----------+------------+
| 66             | keyboard       | 0.70719  | 0.595788  | 0.517122   |
+----------------+----------------+----------+-----------+------------+
| 67             | cell phone     | 0.525349 | 0.385111  | 0.339467   |
+----------------+----------------+----------+-----------+------------+
| 68             | microwave      | 0.76031  | 0.65944   | 0.568955   |
+----------------+----------------+----------+-----------+------------+
| 69             | oven           | 0.565251 | 0.401414  | 0.38584    |
+----------------+----------------+----------+-----------+------------+
| 70             | toaster        | 0.374193 | 0.330104  | 0.251225   |
+----------------+----------------+----------+-----------+------------+
| 71             | sink           | 0.59756  | 0.41998   | 0.397142   |
+----------------+----------------+----------+-----------+------------+
| 72             | refrigerator   | 0.69184  | 0.612432  | 0.543619   |
+----------------+----------------+----------+-----------+------------+
| 73             | book           | 0.233714 | 0.0864857 | 0.109639   |
+----------------+----------------+----------+-----------+------------+
| 74             | clock          | 0.727681 | 0.579384  | 0.511769   |
+----------------+----------------+----------+-----------+------------+
| 75             | vase           | 0.53816  | 0.3856    | 0.363981   |
+----------------+----------------+----------+-----------+------------+
| 76             | scissors       | 0.371954 | 0.307401  | 0.284656   |
+----------------+----------------+----------+-----------+------------+
| 77             | teddy bear     | 0.619803 | 0.479233  | 0.437741   |
+----------------+----------------+----------+-----------+------------+
| 78             | hair drier     | 0        | 0         | 0          |
+----------------+----------------+----------+-----------+------------+
| 79             | toothbrush     | 0.316444 | 0.186356  | 0.186685   |
+----------------+----------------+----------+-----------+------------+
| -              | Mean           | 0.585554 | 0.441032  | 0.406341   |
+----------------+----------------+----------+-----------+------------+
```


## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.