### PR TITLE
[fix] handle error when certain classes have no object in the dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix keyword error of segmentation training by `@illian01` in [PR 551](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/551)
 - Fix typo when saving optimizer state_dict by `@hglee98` in [PR 553](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/553)
 - Fix not initialized save_dtype error by `@hglee98` in [PR 565](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/565)
+- Fix mAP error in case of certain classes object is not in the dataset `@hglee98` in [PR 571](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/571)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/metrics/detection/metric.py
+++ b/src/netspresso_trainer/metrics/detection/metric.py
@@ -132,6 +132,7 @@ def average_precisions_per_class(
     prediction_confidence: np.ndarray,
     prediction_class_ids: np.ndarray,
     true_class_ids: np.ndarray,
+    num_classes: int = 80,
     eps: float = 1e-16,
 ) -> np.ndarray:
     """
@@ -143,6 +144,7 @@ def average_precisions_per_class(
         prediction_confidence (np.ndarray): Objectness value from 0-1.
         prediction_class_ids (np.ndarray): Predicted object classes.
         true_class_ids (np.ndarray): True object classes.
+        num_classes (int): The number of classes.
         eps (float, optional): Small value to prevent division by zero.
 
     Returns:
@@ -153,7 +155,6 @@ def average_precisions_per_class(
     prediction_class_ids = prediction_class_ids[sorted_indices]
 
     unique_classes, class_counts = np.unique(true_class_ids, return_counts=True)
-    num_classes = unique_classes.shape[0]
 
     average_precisions = np.zeros((num_classes, matches.shape[1]))
 
@@ -172,7 +173,7 @@ def average_precisions_per_class(
 
         for iou_level_idx in range(matches.shape[1]):
             average_precisions[
-                class_idx, iou_level_idx
+                int(class_id), iou_level_idx
             ] = compute_average_precision(
                 recall[:, iou_level_idx], precision[:, iou_level_idx]
             )
@@ -233,7 +234,7 @@ class mAP50(BaseMetric):
         # Compute average precisions if any matches exist
         if stats:
             concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
-            average_precisions = average_precisions_per_class(*concatenated_stats)
+            average_precisions = average_precisions_per_class(*concatenated_stats, num_classes=self.num_classes)
 
             if self.classwise_analysis:
                 for i, classwise_meter in enumerate(self.classwise_metric_meters):
@@ -255,7 +256,7 @@ class mAP75(BaseMetric):
         # Compute average precisions if any matches exist
         if stats:
             concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
-            average_precisions = average_precisions_per_class(*concatenated_stats)
+            average_precisions = average_precisions_per_class(*concatenated_stats, num_classes=self.num_classes)
 
             if self.classwise_analysis:
                 for i, classwise_meter in enumerate(self.classwise_metric_meters):
@@ -277,7 +278,7 @@ class mAP50_95(BaseMetric):
         # Compute average precisions if any matches exist
         if stats:
             concatenated_stats = [np.concatenate(items, 0) for items in zip(*stats)]
-            average_precisions = average_precisions_per_class(*concatenated_stats)
+            average_precisions = average_precisions_per_class(*concatenated_stats, num_classes=self.num_classes)
 
             if self.classwise_analysis:
                 for i, classwise_meter in enumerate(self.classwise_metric_meters):

--- a/src/netspresso_trainer/metrics/detection/metric.py
+++ b/src/netspresso_trainer/metrics/detection/metric.py
@@ -132,7 +132,7 @@ def average_precisions_per_class(
     prediction_confidence: np.ndarray,
     prediction_class_ids: np.ndarray,
     true_class_ids: np.ndarray,
-    num_classes: int = 80,
+    num_classes,
     eps: float = 1e-16,
 ) -> np.ndarray:
     """
@@ -156,14 +156,13 @@ def average_precisions_per_class(
 
     unique_classes, class_counts = np.unique(true_class_ids, return_counts=True)
 
-    average_precisions = np.zeros((num_classes, matches.shape[1]))
+    average_precisions = np.full((num_classes, matches.shape[1]), np.nan)
 
     for class_idx, class_id in enumerate(unique_classes):
         is_class = prediction_class_ids == class_id
         total_true = class_counts[class_idx]
-        total_prediction = is_class.sum()
 
-        if total_prediction == 0 or total_true == 0:
+        if total_true == 0:
             continue
 
         false_positives = (1 - matches[is_class]).cumsum(0)
@@ -239,7 +238,7 @@ class mAP50(BaseMetric):
             if self.classwise_analysis:
                 for i, classwise_meter in enumerate(self.classwise_metric_meters):
                     classwise_meter.update(average_precisions[i, 0])
-            self.metric_meter.update(average_precisions[:, 0].mean())
+            self.metric_meter.update(np.nanmean(average_precisions[:, 0]))
         else:
             self.metric_meter.update(0)
 
@@ -261,7 +260,7 @@ class mAP75(BaseMetric):
             if self.classwise_analysis:
                 for i, classwise_meter in enumerate(self.classwise_metric_meters):
                     classwise_meter.update(average_precisions[i, 5])
-            self.metric_meter.update(average_precisions[:, 5].mean())
+            self.metric_meter.update(np.nanmean(average_precisions[:, 5]))
         else:
             self.metric_meter.update(0)
 
@@ -282,7 +281,7 @@ class mAP50_95(BaseMetric):
 
             if self.classwise_analysis:
                 for i, classwise_meter in enumerate(self.classwise_metric_meters):
-                    classwise_meter.update(average_precisions[i, :].mean())
-            self.metric_meter.update(average_precisions.mean())
+                    classwise_meter.update(np.nanmean(average_precisions[i, :]))
+            self.metric_meter.update(np.nanmean(average_precisions))
         else:
             self.metric_meter.update(0)


### PR DESCRIPTION
## Description

This PR aims to fix an issue about the classwise analysis below.

- In a dataset with class imbalance, there may be classes that have no objects at all.
- In this case, the calculated average precision matrix has missing values and raises an error.

Closes: N/A

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Handle an issue above

- [ ] Fix the logic for calculating average precision.

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.