### PR TITLE
[!HOTFIX] Handle error when saving model checkpoints and artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix error of checkpoint saving by `@hglee98` in [PR 580](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/580/files)
 
 ## Breaking Changes:
 

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -279,12 +279,14 @@ class TrainingPipeline(BasePipeline):
         else:
             model = self.model.module if hasattr(self.model, 'module') else self.model
 
+        model = copy.deepcopy(model)
+
         if hasattr(model, 'deploy'):
             model.deploy()
 
         save_dtype = model.save_dtype
         if save_dtype == torch.float16:
-            model = copy.deepcopy(model).type(save_dtype)
+            model = model.type(save_dtype)
 
         logging_dir = self.logger.result_dir
         save_best_only = self.conf.logging.model_save_options.save_best_only

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -281,9 +281,6 @@ class TrainingPipeline(BasePipeline):
 
         model = copy.deepcopy(model)
 
-        if hasattr(model, 'deploy'):
-            model.deploy()
-
         save_dtype = model.save_dtype
         if save_dtype == torch.float16:
             model = model.type(save_dtype)
@@ -328,8 +325,6 @@ class TrainingPipeline(BasePipeline):
 
         model = self.model.module if hasattr(self.model, 'module') else self.model
         best_model = copy.deepcopy(model)
-        if hasattr(best_model, 'deploy'):
-            best_model.deploy()
 
         save_dtype = best_model.save_dtype
         if save_dtype == torch.float16:
@@ -344,6 +339,8 @@ class TrainingPipeline(BasePipeline):
         self._save_model(model=best_model, epoch=best_epoch, model_name_tag="best", logging_dir=logging_dir)
 
         try:
+            if hasattr(best_model, 'deploy'):
+                best_model.deploy()
             model_save_path = Path(logging_dir) / f"{self.task}_{self.model_name}_best.ext"
 
             save_onnx(best_model,


### PR DESCRIPTION
## Description

A critical issue is identified when training models containing re-parametrizable blocks. This issue occurs because the original model structure changes during the checkpoint saving process. To resolve this, I implement a deepcopy function that runs before saving the model artifacts.

## Change(s)

- Add deepcopy function before conducting reparam

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.