### PR TITLE
[refactor] RT-DETR hybrid encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ No changes to highlight.
 
 ## Other Changes:
 
-No changes to highlight.
+- Refactor RT-DETR and generalize CSPRepLayer and RepVGG block by `@hglee98` in [PR 581](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/581)
 
 # v1.0.3
 

--- a/src/netspresso_trainer/models/necks/experimental/rtdetr_hybrid_encoder.py
+++ b/src/netspresso_trainer/models/necks/experimental/rtdetr_hybrid_encoder.py
@@ -28,34 +28,7 @@ import torch.nn.functional as F
 
 from ...utils import BackboneOutput
 from ...op.registry import ACTIVATION_REGISTRY
-from ...op.custom import RepConv, ConvLayer
-
-
-class CSPRepLayer(nn.Module):
-    def __init__(self,
-                 in_channels: int,
-                 out_channels: int,
-                 num_blocks: int=3,
-                 expansion: float=1.0,
-                 bias: bool= False,
-                 act: str="silu"):
-        super(CSPRepLayer, self).__init__()
-        hidden_channels = int(out_channels * expansion)
-        self.conv1 = ConvLayer(in_channels, hidden_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
-        self.conv2 = ConvLayer(in_channels, hidden_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
-        self.bottlenecks = nn.Sequential(*[
-            RepConv(hidden_channels, hidden_channels, act_type=act) for _ in range(num_blocks)
-        ])
-        if hidden_channels != out_channels:
-            self.conv3 = ConvLayer(hidden_channels, out_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
-        else:
-            self.conv3 = nn.Identity()
-
-    def forward(self, x):
-        x_1 = self.conv1(x)
-        x_1 = self.bottlenecks(x_1)
-        x_2 = self.conv2(x)
-        return self.conv3(x_1 + x_2)
+from ...op.custom import RepConv, ConvLayer, CSPRepLayer
 
 
 # transformer

--- a/src/netspresso_trainer/models/necks/experimental/rtdetr_hybrid_encoder.py
+++ b/src/netspresso_trainer/models/necks/experimental/rtdetr_hybrid_encoder.py
@@ -52,12 +52,12 @@ class ConvNormLayer(nn.Module):
 # TODO: Replace with custom implementation
 class CSPRepLayer(nn.Module):
     def __init__(self,
-                 in_channels,
-                 out_channels,
-                 num_blocks=3,
-                 expansion=1.0,
-                 bias=None,
-                 act="silu"):
+                 in_channels: int,
+                 out_channels: int,
+                 num_blocks: int=3,
+                 expansion: float=1.0,
+                 bias: bool= False,
+                 act: str="silu"):
         super(CSPRepLayer, self).__init__()
         hidden_channels = int(out_channels * expansion)
         self.conv1 = ConvNormLayer(in_channels, hidden_channels, 1, 1, bias=bias, act=act)

--- a/src/netspresso_trainer/models/necks/experimental/rtdetr_hybrid_encoder.py
+++ b/src/netspresso_trainer/models/necks/experimental/rtdetr_hybrid_encoder.py
@@ -28,7 +28,7 @@ import torch.nn.functional as F
 
 from ...utils import BackboneOutput
 from ...op.registry import ACTIVATION_REGISTRY
-from ...op.custom import RepConv, ConvLayer, CSPRepLayer
+from ...op.custom import RepVGGBlock, ConvLayer, CSPRepLayer
 
 
 # transformer

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -20,6 +20,7 @@ import warnings
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -171,7 +172,7 @@ class SeparableConvLayer(nn.Module):
         x = self.final_act(x)
         return x
 
-class RepConv(nn.Module):
+class RepVGGBlock(nn.Module):
     """
     A convolutional block that combines two convolution layers (kernel and point-wise conv).
     """

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -186,6 +186,8 @@ class RepConv(nn.Module):
         assert isinstance(in_channels, int)
         assert isinstance(out_channels, int)
         assert isinstance(act_type, str)
+        self.in_channels = in_channels
+        self.out_channels = out_channels
         self.conv1 = ConvLayer(in_channels, out_channels, kernel_size, use_act=False)
         self.conv2 = ConvLayer(in_channels, out_channels, 1, use_act=False)
 
@@ -199,7 +201,7 @@ class RepConv(nn.Module):
 
     def convert_to_deploy(self):
         if not hasattr(self, 'conv'):
-            self.conv = nn.Conv2d(self.ch_in, self.ch_out, 3, 1, padding=1)
+            self.conv = nn.Conv2d(self.in_channels, self.out_channels, kernel_size=3, stride=1, padding=1)
 
         kernel, bias = self.get_equivalent_kernel_bias()
         self.conv.weight.data = kernel

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -829,7 +829,7 @@ class CSPRepLayer(nn.Module):
         self.conv1 = ConvLayer(in_channels, hidden_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
         self.conv2 = ConvLayer(in_channels, hidden_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
         self.bottlenecks = nn.Sequential(*[
-            RepConv(hidden_channels, hidden_channels, act_type=act) for _ in range(num_blocks)
+            RepVGGBlock(hidden_channels, hidden_channels, act_type=act) for _ in range(num_blocks)
         ])
         if hidden_channels != out_channels:
             self.conv3 = ConvLayer(hidden_channels, out_channels, kernel_size=1, stride=1, bias=bias, act_type=act)

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -181,6 +181,7 @@ class RepVGGBlock(nn.Module):
                  in_channels: int,
                  out_channels: int,
                  kernel_size: Union[int, Tuple[int, int]] = 3,
+                 groups: int = 1,
                  act_type: Optional[str] = None,):
         if act_type is None:
             act_type = 'silu'
@@ -192,8 +193,9 @@ class RepVGGBlock(nn.Module):
 
         self.in_channels = in_channels
         self.out_channels = out_channels
-        self.conv1 = ConvLayer(in_channels, out_channels, kernel_size, use_act=False)
-        self.conv2 = ConvLayer(in_channels, out_channels, 1, use_act=False)
+        self.groups = groups
+        self.conv1 = ConvLayer(in_channels, out_channels, kernel_size, groups=groups, use_act=False)
+        self.conv2 = ConvLayer(in_channels, out_channels, 1, groups=groups, use_act=False)
         self.rbr_identity = nn.BatchNorm2d(num_features=in_channels) if out_channels == in_channels else None
 
         assert act_type in ACTIVATION_REGISTRY

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -175,6 +175,7 @@ class SeparableConvLayer(nn.Module):
 class RepVGGBlock(nn.Module):
     """
     A convolutional block that combines two convolution layers (kernel and point-wise conv).
+    This implementation is based on https://github.com/lyuwenyu/RT-DETR/blob/b444daf79cf25f95b740ae71e80fd165e892739a/rtdetr_pytorch/src/zoo/rtdetr/hybrid_encoder.py#L35.
     """
     def __init__(self,
                  in_channels: int,

--- a/src/netspresso_trainer/models/op/custom.py
+++ b/src/netspresso_trainer/models/op/custom.py
@@ -786,6 +786,32 @@ class CSPLayer(nn.Module):
         return self.conv3(x)
 
 
+class CSPRepLayer(nn.Module):
+    def __init__(self,
+                 in_channels: int,
+                 out_channels: int,
+                 num_blocks: int=3,
+                 expansion: float=1.0,
+                 bias: bool= False,
+                 act: str="silu"):
+        super(CSPRepLayer, self).__init__()
+        hidden_channels = int(out_channels * expansion)
+        self.conv1 = ConvLayer(in_channels, hidden_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
+        self.conv2 = ConvLayer(in_channels, hidden_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
+        self.bottlenecks = nn.Sequential(*[
+            RepConv(hidden_channels, hidden_channels, act_type=act) for _ in range(num_blocks)
+        ])
+        if hidden_channels != out_channels:
+            self.conv3 = ConvLayer(hidden_channels, out_channels, kernel_size=1, stride=1, bias=bias, act_type=act)
+        else:
+            self.conv3 = nn.Identity()
+
+    def forward(self, x):
+        x_1 = self.conv1(x)
+        x_1 = self.bottlenecks(x_1)
+        x_2 = self.conv2(x)
+        return self.conv3(x_1 + x_2)
+
 class SPPBottleneck(nn.Module):
     """Spatial pyramid pooling layer used in YOLOv3-SPP"""
 


### PR DESCRIPTION
## Description

This PR aims to refactor replaceable blocks within RT-DETR hybrid encoder (e.g., ConvNormLayer, RepVGG). 

Closes: #529 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Move `CSPRepLayer` to op.custom
- Replace `ConvNormLayer` to `ConvLayer` in op.custom
- Replace `RepVGG` with custom operation layers.

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.