### PR TITLE
[feat] Implement yolov9 loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add instance number logging feature for detection task by `@hglee98` in [PR 577](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/577)
 - Add Precision and Recall metric for detection task by `@hglee98` in [PR 579](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/579)
-- Add YOLOv9 by `@hglee98` in [PR 585](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/585), [PR 586](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/586), [PR 592](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/592), [PR 593](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/593)
+- Add YOLOv9 by `@hglee98` in [PR 585](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/585), [PR 586](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/586), [PR 592](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/592), [PR 593](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/593), [PR 595](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/595)
 
 ## Bug Fixes:
 

--- a/src/netspresso_trainer/losses/detection/__init__.py
+++ b/src/netspresso_trainer/losses/detection/__init__.py
@@ -17,4 +17,5 @@
 from .retinanet import RetinaNetLoss
 from .rtdetr import DETRLoss
 from .yolo import YOLOFastestLoss
+from .yolov9 import YOLOv9Loss
 from .yolox import YOLOXLoss

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2024 Nota Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ----------------------------------------------------------------------------

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -104,8 +104,8 @@ class BoxMatcher:
         self.class_num = class_num
         self.anchors = anchors
         self.iou = "ciou"
-        self.topk = 10
-        self.factor = {"iou": 6.0, "cls": 0.5}
+        self.topk = 10 # TODO: It should be parameterized.
+        self.factor = {"iou": 6.0, "cls": 0.5} # TODO: It should be parameterized.
 
     def get_valid_matrix(self, target_bbox: Tensor):
         """

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -29,6 +29,7 @@ from .yolox import IOUloss
 
 
 def calculate_iou(bbox1, bbox2, metrics="iou") -> Tensor:
+    #TODO: It should be consolidated into bbox_utils 
     metrics = metrics.lower()
     EPS = 1e-7
     dtype = bbox1.dtype

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -15,7 +15,7 @@
 # ----------------------------------------------------------------------------
 
 import math
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Tuple
 
 import torch
 import torch.nn as nn

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -13,3 +13,240 @@
 # limitations under the License.
 #
 # ----------------------------------------------------------------------------
+
+import math
+from typing import Any, Dict, List, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn import BCEWithLogitsLoss
+
+from netspresso_trainer.utils.bbox_utils import BoxMatcher, generate_anchors
+
+from .yolox import IOUloss
+
+
+def calculate_iou(bbox1, bbox2, metrics="iou") -> Tensor:
+    metrics = metrics.lower()
+    EPS = 1e-7
+    dtype = bbox1.dtype
+    bbox1 = bbox1.to(torch.float32)
+    bbox2 = bbox2.to(torch.float32)
+
+    # Expand dimensions if necessary
+    if bbox1.ndim == 2 and bbox2.ndim == 2:
+        bbox1 = bbox1.unsqueeze(1)  # (Ax4) -> (Ax1x4)
+        bbox2 = bbox2.unsqueeze(0)  # (Bx4) -> (1xBx4)
+    elif bbox1.ndim == 3 and bbox2.ndim == 3:
+        bbox1 = bbox1.unsqueeze(2)  # (BZxAx4) -> (BZxAx1x4)
+        bbox2 = bbox2.unsqueeze(1)  # (BZxBx4) -> (BZx1xBx4)
+
+    # Calculate intersection coordinates
+    xmin_inter = torch.max(bbox1[..., 0], bbox2[..., 0])
+    ymin_inter = torch.max(bbox1[..., 1], bbox2[..., 1])
+    xmax_inter = torch.min(bbox1[..., 2], bbox2[..., 2])
+    ymax_inter = torch.min(bbox1[..., 3], bbox2[..., 3])
+
+    # Calculate intersection area
+    intersection_area = torch.clamp(xmax_inter - xmin_inter, min=0) * torch.clamp(ymax_inter - ymin_inter, min=0)
+
+    # Calculate area of each bbox
+    area_bbox1 = (bbox1[..., 2] - bbox1[..., 0]) * (bbox1[..., 3] - bbox1[..., 1])
+    area_bbox2 = (bbox2[..., 2] - bbox2[..., 0]) * (bbox2[..., 3] - bbox2[..., 1])
+
+    # Calculate union area
+    union_area = area_bbox1 + area_bbox2 - intersection_area
+
+    # Calculate IoU
+    iou = intersection_area / (union_area + EPS)
+    if metrics == "iou":
+        return iou.to(dtype)
+
+    # Calculate centroid distance
+    cx1 = (bbox1[..., 2] + bbox1[..., 0]) / 2
+    cy1 = (bbox1[..., 3] + bbox1[..., 1]) / 2
+    cx2 = (bbox2[..., 2] + bbox2[..., 0]) / 2
+    cy2 = (bbox2[..., 3] + bbox2[..., 1]) / 2
+    cent_dis = (cx1 - cx2) ** 2 + (cy1 - cy2) ** 2
+
+    # Calculate diagonal length of the smallest enclosing box
+    c_x = torch.max(bbox1[..., 2], bbox2[..., 2]) - torch.min(bbox1[..., 0], bbox2[..., 0])
+    c_y = torch.max(bbox1[..., 3], bbox2[..., 3]) - torch.min(bbox1[..., 1], bbox2[..., 1])
+    diag_dis = c_x**2 + c_y**2 + EPS
+
+    diou = iou - (cent_dis / diag_dis)
+    if metrics == "diou":
+        return diou.to(dtype)
+
+    # Compute aspect ratio penalty term
+    arctan = torch.atan((bbox1[..., 2] - bbox1[..., 0]) / (bbox1[..., 3] - bbox1[..., 1] + EPS)) - torch.atan(
+        (bbox2[..., 2] - bbox2[..., 0]) / (bbox2[..., 3] - bbox2[..., 1] + EPS)
+    )
+    v = (4 / (math.pi**2)) * (arctan**2)
+    with torch.no_grad():
+        alpha = v / (v - iou + 1 + EPS)
+    # Compute CIoU
+    ciou = diou - alpha * v
+    return ciou.to(dtype)
+
+
+
+class BoxMatcher:
+    def __init__(self,
+                 class_num: int,
+                 anchors: Tensor,
+
+                 ) -> None:
+        self.class_num = class_num
+        self.anchors = anchors
+        self.iou = "ciou"
+        self.topk = 10
+        self.factor = {"iou": 6.0, "cls": 0.5}
+
+    def get_valid_matrix(self, target_bbox: Tensor):
+        """
+        Get a boolean mask that indicates whether each target bounding box overlaps with each anchor.
+
+        Args:
+            target_bbox [batch x targets x 4]: The bounding box of each targets.
+        Returns:
+            [batch x targets x anchors]: A boolean tensor indicates if target bounding box overlaps with anchors.
+        """
+        Xmin, Ymin, Xmax, Ymax = target_bbox[:, :, None].unbind(3)
+        anchors = self.anchors[None, None]  # add a axis at first, second dimension
+        anchors_x, anchors_y = anchors.unbind(dim=3)
+        target_in_x = (Xmin < anchors_x) & (anchors_x < Xmax)
+        target_in_y = (Ymin < anchors_y) & (anchors_y < Ymax)
+        target_on_anchor = target_in_x & target_in_y
+        return target_on_anchor
+
+    def get_cls_matrix(self, predict_cls: Tensor, target_cls: Tensor) -> Tensor:
+        """
+        Get the (predicted class' probabilities) corresponding to the target classes across all anchors
+
+        Args:
+            predict_cls [batch x anchors x class]: The predicted probabilities for each class across each anchor.
+            target_cls [batch x targets]: The class index for each target.
+
+        Returns:
+            [batch x targets x anchors]: The probabilities from `pred_cls` corresponding to the class indices specified in `target_cls`.
+        """
+        predict_cls = predict_cls.transpose(1, 2)
+        target_cls = target_cls.expand(-1, -1, predict_cls.size(2))
+        cls_probabilities = torch.gather(predict_cls, 1, target_cls)
+        return cls_probabilities
+
+    def get_iou_matrix(self, predict_bbox, target_bbox) -> Tensor:
+        """
+        Get the IoU between each target bounding box and each predicted bounding box.
+
+        Args:
+            predict_bbox [batch x predicts x 4]: Bounding box with [x1, y1, x2, y2].
+            target_bbox [batch x targets x 4]: Bounding box with [x1, y1, x2, y2].
+        Returns:
+            [batch x targets x predicts]: The IoU scores between each target and predicted.
+        """
+        return calculate_iou(target_bbox, predict_bbox, self.iou).clamp(0, 1)
+
+    def filter_topk(self, target_matrix: Tensor, topk: int = 10) -> Tuple[Tensor, Tensor]:
+        """
+        Filter the top-k suitability of targets for each anchor.
+
+        Args:
+            target_matrix [batch x targets x anchors]: The suitability for each targets-anchors
+            topk (int, optional): Number of top scores to retain per anchor.
+
+        Returns:
+            topk_targets [batch x targets x anchors]: Only leave the topk targets for each anchor
+            topk_masks [batch x targets x anchors]: A boolean mask indicating the top-k scores' positions.
+        """
+        values, indices = target_matrix.topk(topk, dim=-1)
+        topk_targets = torch.zeros_like(target_matrix, device=target_matrix.device)
+        topk_targets.scatter_(dim=-1, index=indices, src=values)
+        topk_masks = topk_targets > 0
+        return topk_targets, topk_masks
+
+    def filter_duplicates(self, target_matrix: Tensor, topk_mask: Tensor):
+        """
+        Filter the maximum suitability target index of each anchor.
+
+        Args:
+            target_matrix [batch x targets x anchors]: The suitability for each targets-anchors
+
+        Returns:
+            unique_indices [batch x anchors x 1]: The index of the best targets for each anchors
+        """
+        duplicates = (topk_mask.sum(1, keepdim=True) > 1).repeat([1, topk_mask.size(1), 1])
+        max_idx = F.one_hot(target_matrix.argmax(1), topk_mask.size(1)).permute(0, 2, 1)
+        topk_mask = torch.where(duplicates, max_idx, topk_mask)
+        unique_indices = topk_mask.argmax(dim=1)
+        return unique_indices[..., None], topk_mask.sum(1), topk_mask
+
+    def __call__(self, target: Tensor, predict: Tuple[Tensor]) -> Tuple[Tensor, Tensor]:
+        """Matches each target to the most suitable anchor.
+        1. For each anchor prediction, find the highest suitability targets.
+        2. Match target to the best anchor.
+        3. Noramlize the class probilities of targets.
+
+        Args:
+            target: The ground truth class and bounding box information
+                as tensor of size [batch x targets x 5].
+            predict: Tuple of predicted class and bounding box tensors.
+                Class tensor is of size [batch x anchors x class]
+                Bounding box tensor is of size [batch x anchors x 4].
+
+        Returns:
+            anchor_matched_targets: Tensor of size [batch x anchors x (class + 4)].
+                A tensor assigning each target/gt to the best fitting anchor.
+                The class probabilities are normalized.
+            valid_mask: Bool tensor of shape [batch x anchors].
+                True if a anchor has a target/gt assigned to it.
+        """
+        predict_cls, predict_bbox = predict
+
+        # return if target has no gt information.
+        n_targets = target.shape[1]
+        if n_targets == 0:
+            device = predict_bbox.device
+            align_cls = torch.zeros_like(predict_cls, device=device)
+            align_bbox = torch.zeros_like(predict_bbox, device=device)
+            valid_mask = torch.zeros(predict_cls.shape[:2], dtype=bool, device=device)
+            anchor_matched_targets = torch.cat([align_cls, align_bbox], dim=-1)
+            return anchor_matched_targets, valid_mask
+
+        target_cls, target_bbox = target.split([1, 4], dim=-1)  # B x N x (C B) -> B x N x C, B x N x B
+        target_cls = target_cls.long().clamp(0)
+
+        # get valid matrix (each gt appear in which anchor grid)
+        grid_mask = self.get_valid_matrix(target_bbox)
+
+        # get iou matrix (iou with each gt bbox and each predict anchor)
+        iou_mat = self.get_iou_matrix(predict_bbox, target_bbox)
+
+        # get cls matrix (cls prob with each gt class and each predict class)
+        cls_mat = self.get_cls_matrix(predict_cls.sigmoid(), target_cls)
+
+        target_matrix = grid_mask * (iou_mat ** self.factor["iou"]) * (cls_mat ** self.factor["cls"])
+
+        # choose topk
+        topk_targets, topk_mask = self.filter_topk(target_matrix, topk=self.topk)
+
+        # delete one anchor pred assign to mutliple gts
+        unique_indices, valid_mask, topk_mask = self.filter_duplicates(iou_mat, topk_mask)
+
+        align_bbox = torch.gather(target_bbox, 1, unique_indices.repeat(1, 1, 4))
+        align_cls = torch.gather(target_cls, 1, unique_indices).squeeze(-1)
+        align_cls = F.one_hot(align_cls, self.class_num)
+
+        # normalize class ditribution
+        iou_mat *= topk_mask
+        target_matrix *= topk_mask
+        max_target = target_matrix.amax(dim=-1, keepdim=True)
+        max_iou = iou_mat.amax(dim=-1, keepdim=True)
+        normalize_term = (target_matrix / (max_target + 1e-9)) * max_iou
+        normalize_term = normalize_term.permute(0, 2, 1).gather(2, unique_indices)
+        align_cls = align_cls * normalize_term * valid_mask[:, :, None]
+        anchor_matched_targets = torch.cat([align_cls, align_bbox], dim=-1)
+        return anchor_matched_targets, valid_mask.bool()

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -95,6 +95,7 @@ def calculate_iou(bbox1, bbox2, metrics="iou") -> Tensor:
 
 
 class BoxMatcher:
+    # TODO: It should be consolidated into bbox_utils 
     def __init__(self,
                  class_num: int,
                  anchors: Tensor,

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -27,6 +27,10 @@ from netspresso_trainer.utils.bbox_utils import BoxMatcher, generate_anchors
 
 from .yolox import IOUloss
 
+"""
+    This implementation is based on https://github.com/WongKinYiu/YOLO/blob/main/yolo/tools/loss_functions.py.
+"""
+
 
 def calculate_iou(bbox1, bbox2, metrics="iou") -> Tensor:
     #TODO: It should be consolidated into bbox_utils 

--- a/src/netspresso_trainer/losses/registry.py
+++ b/src/netspresso_trainer/losses/registry.py
@@ -15,7 +15,7 @@
 # ----------------------------------------------------------------------------
 
 from .common import CrossEntropyLoss, SigmoidFocalLoss
-from .detection import DETRLoss, RetinaNetLoss, YOLOFastestLoss, YOLOXLoss
+from .detection import DETRLoss, RetinaNetLoss, YOLOFastestLoss, YOLOv9Loss, YOLOXLoss
 from .pose_estimation import RTMCCLoss
 from .segmentation import PIDNetLoss, SegCrossEntropyLoss
 
@@ -25,6 +25,7 @@ LOSS_DICT = {
     'pidnet_loss': PIDNetLoss,
     'yolox_loss': YOLOXLoss,
     'yolofastest_loss': YOLOFastestLoss,
+    'yolov9_loss': YOLOv9Loss,
     'retinanet_loss': RetinaNetLoss,
     'detr_loss': DETRLoss,
     'focal_loss': SigmoidFocalLoss,


### PR DESCRIPTION
## Description

This PR aims to support yolov9 loss feature. 

Related to #582.

## Change(s)

- Implement yolov9 loss

TODOs for later
- [ ] topk, factor attr in BoxMatcher should be controlled by config.
- [ ] BoxMatcher module and caculate_iou method should be moved to bbox_utils module.

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.