### PR TITLE
[fix] Relocate anchor2vec outside the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add instance number logging feature for detection task by `@hglee98` in [PR 577](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/577)
 - Add Precision and Recall metric for detection task by `@hglee98` in [PR 579](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/579)
-- Add YOLOv9 by `@hglee98` in [PR 585](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/585), [PR 586](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/586), [PR 592](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/592), [PR 593](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/593), [PR 595](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/595), [PR 589](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/589), [PR 590](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/590), [PR 597](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/597), [PR 598](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/598)
+- Add YOLOv9 by `@hglee98` in [PR 585](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/585), [PR 586](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/586), [PR 592](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/592), [PR 593](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/593), [PR 595](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/595), [PR 589](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/589), [PR 590](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/590), [PR 597](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/597), [PR 598](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/598), [PR 601](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/601)
 
 ## Bug Fixes:
 

--- a/config/model/yolo/yolov9_c-detection.yaml
+++ b/config/model/yolo/yolov9_c-detection.yaml
@@ -55,17 +55,19 @@ model:
         version: v9
         num_anchors: ~
         use_group: true
-        reg_max: 16
+        reg_max: &reg_max 16
         act_type: *act_type
         use_aux_loss: *use_aux_loss
   postprocessor: 
     params: 
       # postprocessor - decode
+      reg_max: *reg_max
       score_thresh: 0.01
       # postprocessor - nms
       nms_thresh: 0.65
       class_agnostic: false
   losses:
     - criterion: yolov9_loss
+      reg_max: *reg_max
       weight: ~
       l1_activate_epoch: ~

--- a/config/model/yolo/yolov9_m-detection.yaml
+++ b/config/model/yolo/yolov9_m-detection.yaml
@@ -55,17 +55,19 @@ model:
         version: v9
         num_anchors: ~
         use_group: true
-        reg_max: 16
+        reg_max: &reg_max 16
         act_type: *act_type
         use_aux_loss: *use_aux_loss
   postprocessor: 
     params: 
       # postprocessor - decode
+      reg_max: *reg_max
       score_thresh: 0.01
       # postprocessor - nms
       nms_thresh: 0.65
       class_agnostic: false
   losses:
     - criterion: yolov9_loss
+      reg_max: *reg_max
       weight: ~
       l1_activate_epoch: ~

--- a/config/model/yolo/yolov9_s-detection.yaml
+++ b/config/model/yolo/yolov9_s-detection.yaml
@@ -55,17 +55,19 @@ model:
         version: v9
         num_anchors: ~
         use_group: true
-        reg_max: 16
+        reg_max: &reg_max 16
         act_type: *act_type
         use_aux_loss: *use_aux_loss
   postprocessor: 
     params: 
       # postprocessor - decode
+      reg_max: *reg_max
       score_thresh: 0.01
       # postprocessor - nms
       nms_thresh: 0.65
       class_agnostic: false
   losses:
     - criterion: yolov9_loss
+      reg_max: *reg_max
       weight: ~
       l1_activate_epoch: ~

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -23,6 +23,7 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import BCEWithLogitsLoss
 
+from netspresso_trainer.models.op.custom import Anchor2Vec
 from netspresso_trainer.utils.bbox_utils import generate_anchors
 
 from .yolox import IOUloss
@@ -326,12 +327,14 @@ class YOLOv9Loss(nn.Module):
         self.cls = BCELoss()
         self.iou = BoxLoss()
         self.reg_max = kwargs.get("reg_max", 16)
+        self.anc2vec = Anchor2Vec(self.reg_max)
         self.aux_rate = 0.25 # TODO: should be controlled by config
 
     def get_output(self, output, anchor_grid, scaler):
         pred_bbox_reg, pred_bbox_anchor, pred_class_logits = [], [], []
         for layer_output in output:
-            bbox_reg, bbox_anchor, class_logits = layer_output
+            reg, class_logits = torch.split(layer_output, [layer_output.shape[1] - self.num_classes, self.num_classes], dim=1)
+            bbox_anchor, bbox_reg = self.anc2vec(reg)
             b, c, _, _ = bbox_reg.shape
             reg = bbox_reg.view(b, c, -1).permute(0, 2, 1)
             pred_bbox_reg.append(reg)
@@ -370,8 +373,7 @@ class YOLOv9Loss(nn.Module):
 
         strides = []
         for _k, o in enumerate(out):
-            bbox_reg, _, _ = o
-            stride_this_level = img_size[-1] // bbox_reg.size(-1)
+            stride_this_level = img_size[-1] // o.size(-1)
             strides.append(stride_this_level)
         anchor_grid, scaler = generate_anchors(img_size, strides)
         anchor_grid = anchor_grid.to(device)

--- a/src/netspresso_trainer/losses/detection/yolov9.py
+++ b/src/netspresso_trainer/losses/detection/yolov9.py
@@ -325,7 +325,7 @@ class YOLOv9Loss(nn.Module):
         self.scaler = None
         self.cls = BCELoss()
         self.iou = BoxLoss()
-        self.reg_max = 16 # TODO: should be controlled by config
+        self.reg_max = kwargs.get("reg_max", 16)
         self.aux_rate = 0.25 # TODO: should be controlled by config
 
     def get_output(self, output, anchor_grid, scaler):

--- a/src/netspresso_trainer/models/heads/detection/experimental/yolo_head.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/yolo_head.py
@@ -88,9 +88,8 @@ class Detection(nn.Module):
     def forward(self, x: Union[Tensor, Proxy]) -> Tuple[Union[Tensor, Proxy]]:
         reg = self.reg_convs(x)
         cls_logits = self.cls_convs(x)
-        anchor_x, vector_x = self.anchor2vec(reg)
-
-        return vector_x, anchor_x, cls_logits
+        output = torch.cat([reg, cls_logits], dim=1)
+        return output
 
 
 class YOLODetectionHead(nn.Module):


### PR DESCRIPTION
## Description
This PR addresses the model compression issues mentioned in #582 by restructuring the Anchor2Vec implementation for compatibility with PyNetsPresso compression framework.

Related to #582 

## Changes
- Relocate Anchor2Vec module outside the model architecture to enable proper compression
- Refactor Anchor2Vec logic for improved functionality
- Add `reg_max` configuration parameter to both loss function and post-processor components


## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.