### PR TITLE
[!HOTFIX] change padding fill value to 114 of yolox augmentation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ No changes to highlight.
 
 ## Bug Fixes:
 
-No changes to highlight.
+- Fix augmentation config of yolox training example by `@hglee98` in [PR 610](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/610)
 
 ## Breaking Changes:
 

--- a/config/benchmark_examples/detection-coco2017-yolox_s/augmentation.yaml
+++ b/config/benchmark_examples/detection-coco2017-yolox_s/augmentation.yaml
@@ -11,7 +11,7 @@ augmentation:
       enable_mixup: True
       mixup_prob: 1.0
       mixup_scale: [0.1, 2.0]
-      fill: 144
+      fill: 114
       mosaic_off_duration: 15
     -
       name: hsvjitter
@@ -54,7 +54,7 @@ augmentation:
     - 
       name: pad
       size: 640
-      fill: 144
+      fill: 114
     -
       name: totensor
       pixel_range: 1.0


### PR DESCRIPTION
## Description

[Megvii-BaseDetection/YOLOX/discussions/983](https://github.com/Megvii-BaseDetection/YOLOX/discussions/983)

Closes: N/A

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Change filling value to be 114

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.