### PR TITLE
[refactor] delete label_size, targets parameters from forward method across models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ No changes to highlight.
 
 ## Other Changes:
 
-No changes to highlight.
+- Delete label_size, targets parameters from forward method across models by `@hglee98` in [PR 611](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/611)
 
 # v0.1.0
 

--- a/src/netspresso_trainer/models/base.py
+++ b/src/netspresso_trainer/models/base.py
@@ -74,7 +74,7 @@ class TaskModel(nn.Module):
             return f"{self.__class__.__name__}[task={self.task}, backbone={self.backbone_name}, head={self.head_name}]"
 
     @abstractmethod
-    def forward(self, x, label_size=None, targets=None):
+    def forward(self, x, targets=None):
         raise NotImplementedError
 
     def deploy(self, ):
@@ -89,7 +89,7 @@ class ClassificationModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, label_size=None, targets=None):
+    def forward(self, x, targets=None):
         features: BackboneOutput = self.backbone(x)
         out: ModelOutput = self.head(features['last_feature'])
         return out
@@ -99,7 +99,7 @@ class SegmentationModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, label_size=None, targets=None):
+    def forward(self, x, targets=None):
         features: BackboneOutput = self.backbone(x)
         if hasattr(self, 'neck'):
             features: BackboneOutput = self.neck(features['intermediate_features'])
@@ -111,7 +111,7 @@ class DetectionModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, label_size=None, targets=None):
+    def forward(self, x, targets=None):
         features: BackboneOutput = self.backbone(x)
         if hasattr(self, 'neck'):
             features: BackboneOutput = self.neck(features['intermediate_features'])
@@ -123,7 +123,7 @@ class PoseEstimationModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, label_size=None, targets=None):
+    def forward(self, x, targets=None):
         features: BackboneOutput = self.backbone(x)
         if hasattr(self, 'neck'):
             features: BackboneOutput = self.neck(features['intermediate_features'])
@@ -150,7 +150,7 @@ class ONNXModel:
     def _get_name(self):
         return f"{self.__class__.__name__}[model={self.name}]"
 
-    def __call__(self, x, label_size=None, targets=None):
+    def __call__(self, x, targets=None):
         device = x.device
         x = x.detach().cpu().numpy()
         out = self.inference_session.run(None, {self.inference_session.get_inputs()[0].name: x})
@@ -211,13 +211,12 @@ class TFLiteModel:
         """Get the name of the model."""
         return f"{self.__class__.__name__}[model={self.name}]"
 
-    def __call__(self, x: Union[np.ndarray, torch.Tensor], label_size=None, targets=None):
+    def __call__(self, x: Union[np.ndarray, torch.Tensor], targets=None):
         """
         Perform inference on the input tensor.
 
         Args:
             x (Union[np.ndarray, torch.Tensor]): Input tensor
-            label_size: Not used in this implementation
             targets: Not used in this implementation
 
         Returns:

--- a/src/netspresso_trainer/models/base.py
+++ b/src/netspresso_trainer/models/base.py
@@ -74,7 +74,7 @@ class TaskModel(nn.Module):
             return f"{self.__class__.__name__}[task={self.task}, backbone={self.backbone_name}, head={self.head_name}]"
 
     @abstractmethod
-    def forward(self, x, targets=None):
+    def forward(self, x):
         raise NotImplementedError
 
     def deploy(self, ):
@@ -89,7 +89,7 @@ class ClassificationModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, targets=None):
+    def forward(self, x):
         features: BackboneOutput = self.backbone(x)
         out: ModelOutput = self.head(features['last_feature'])
         return out
@@ -99,11 +99,11 @@ class SegmentationModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, targets=None):
+    def forward(self, x):
         features: BackboneOutput = self.backbone(x)
         if hasattr(self, 'neck'):
             features: BackboneOutput = self.neck(features['intermediate_features'])
-        out: ModelOutput = self.head(features['intermediate_features'], targets)
+        out: ModelOutput = self.head(features['intermediate_features'])
         return out
 
 
@@ -111,11 +111,11 @@ class DetectionModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, targets=None):
+    def forward(self, x):
         features: BackboneOutput = self.backbone(x)
         if hasattr(self, 'neck'):
             features: BackboneOutput = self.neck(features['intermediate_features'])
-        out: DetectionModelOutput = self.head(features['intermediate_features'], targets)
+        out: DetectionModelOutput = self.head(features['intermediate_features'])
         return out
 
 
@@ -123,11 +123,11 @@ class PoseEstimationModel(TaskModel):
     def __init__(self, conf_model, backbone, neck, head, freeze_backbone=False) -> None:
         super().__init__(conf_model, backbone, neck, head, freeze_backbone)
 
-    def forward(self, x, targets=None):
+    def forward(self, x):
         features: BackboneOutput = self.backbone(x)
         if hasattr(self, 'neck'):
             features: BackboneOutput = self.neck(features['intermediate_features'])
-        out: DetectionModelOutput = self.head(features['intermediate_features'], targets)
+        out: DetectionModelOutput = self.head(features['intermediate_features'])
         return out
 
 

--- a/src/netspresso_trainer/models/heads/classification/core/fc.py
+++ b/src/netspresso_trainer/models/heads/classification/core/fc.py
@@ -45,7 +45,7 @@ class FC(nn.Module):
         classifier.append(nn.Linear(prev_size, num_classes))
         self.classifier = nn.Sequential(*classifier)
         
-    def forward(self, x: Union[Tensor, Proxy], targets=None) -> ModelOutput:
+    def forward(self, x: Union[Tensor, Proxy]) -> ModelOutput:
         x = self.classifier(x)
         return ModelOutput(pred=x)
 
@@ -71,7 +71,7 @@ class FCConv(nn.Module):
 
         self.classifier = nn.Sequential(*classifier)
 
-    def forward(self, x: Union[Tensor, Proxy], targets=None) -> ModelOutput:
+    def forward(self, x: Union[Tensor, Proxy]) -> ModelOutput:
         x = self.classifier(x.unsqueeze(-1).unsqueeze(-1))
         x = torch.flatten(x, 1)
         return ModelOutput(pred=x)

--- a/src/netspresso_trainer/models/heads/detection/experimental/anchor_decoupled_head.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/anchor_decoupled_head.py
@@ -145,7 +145,7 @@ class RetinaNetRegressionHead(nn.Module):
                 if layer.bias is not None:
                     torch.nn.init.zeros_(layer.bias)
 
-    def forward(self, x, targets=None):
+    def forward(self, x):
         all_bbox_regression = []
 
         for features in x:

--- a/src/netspresso_trainer/models/heads/detection/experimental/anchor_free_decoupled_head.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/anchor_free_decoupled_head.py
@@ -149,7 +149,7 @@ class AnchorFreeDecoupledHead(nn.Module):
             b.data.fill_(-math.log((1 - prior_prob) / prior_prob))
             conv.bias = torch.nn.Parameter(b.view(-1), requires_grad=True)
 
-    def forward(self, xin, targets=None):
+    def forward(self, xin):
         outputs = []
 
         for k, (cls_conv, reg_conv, x) in enumerate(zip(self.cls_convs, self.reg_convs, xin)):

--- a/src/netspresso_trainer/models/heads/detection/experimental/yolo_fastest_head.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/yolo_fastest_head.py
@@ -38,7 +38,7 @@ class YOLOFastestHeadV2(nn.Module):
         self.cls_head = YOLOFastestClassificationHead(hidden_dim, self.num_anchors, num_classes)  
         self.reg_head = YOLOFastestRegressionHead(hidden_dim, self.num_anchors) 
 
-    def forward(self, x, target=None):
+    def forward(self, x):
         cls_logits, objs = self.cls_head(x)
         bbox_regression = self.reg_head(x)
         outputs = list()

--- a/src/netspresso_trainer/models/heads/detection/experimental/yolo_head.py
+++ b/src/netspresso_trainer/models/heads/detection/experimental/yolo_head.py
@@ -145,7 +145,7 @@ class YOLODetectionHead(nn.Module):
             heads.append(head)
         return heads
 
-    def forward(self, x_in: Union[List[Tensor], Dict], targets: Optional[Tensor] = None) -> ModelOutput:
+    def forward(self, x_in: Union[List[Tensor], Dict]) -> ModelOutput:
         if isinstance(x_in, Dict):
             assert self.aux_heads
             aux_in = x_in["aux_outputs"]

--- a/src/netspresso_trainer/models/heads/pose_estimation/experimental/rtmcc.py
+++ b/src/netspresso_trainer/models/heads/pose_estimation/experimental/rtmcc.py
@@ -378,7 +378,7 @@ class RTMCC(nn.Module):
         self.cls_x = nn.Linear(attention_channels, W, bias=False)
         self.cls_y = nn.Linear(attention_channels, H, bias=False)
 
-    def forward(self, encoder_hidden_states: FXTensorListType, targets=None):
+    def forward(self, encoder_hidden_states: FXTensorListType):
         out = encoder_hidden_states[-1]
 
         out = self.final_layer(out)  # -> B, K, H, W

--- a/src/netspresso_trainer/models/heads/segmentation/experimental/all_mlp_decoder.py
+++ b/src/netspresso_trainer/models/heads/segmentation/experimental/all_mlp_decoder.py
@@ -53,7 +53,7 @@ class AllMLPDecoder(nn.Module):
         self.dropout = nn.Dropout(classifier_dropout_prob)
         self.classifier = nn.Conv2d(intermediate_channels, num_classes, kernel_size=1)
 
-    def forward(self, encoder_hidden_states: FXTensorListType, targets=None):
+    def forward(self, encoder_hidden_states: FXTensorListType):
 
         all_hidden_states = ()
         for encoder_hidden_state, mlp in zip(encoder_hidden_states, self.linear_c):

--- a/src/netspresso_trainer/pipelines/task_processors/classification.py
+++ b/src/netspresso_trainer/pipelines/task_processors/classification.py
@@ -36,6 +36,12 @@ class ClassificationProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
+            if isinstance(train_model, torch.nn.parallel.DistributedDataParallel):
+                if hasattr(train_model.module.head, "_training_targets"): # for RT-DETR
+                    train_model.module.head.set_training_targets(target)
+            else:
+                if hasattr(train_model.head, "_training_targets"):
+                    train_model.head.set_training_targets(target)
             out = train_model(images)
             loss_factory.calc(out, target, phase='train')
         if labels.dim() > 1: # Soft label to label number

--- a/src/netspresso_trainer/pipelines/task_processors/classification.py
+++ b/src/netspresso_trainer/pipelines/task_processors/classification.py
@@ -36,7 +36,7 @@ class ClassificationProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
-            out = train_model(images, targets=target)
+            out = train_model(images)
             loss_factory.calc(out, target, phase='train')
         if labels.dim() > 1: # Soft label to label number
             labels = torch.argmax(labels, dim=-1)

--- a/src/netspresso_trainer/pipelines/task_processors/detection.py
+++ b/src/netspresso_trainer/pipelines/task_processors/detection.py
@@ -40,6 +40,12 @@ class DetectionProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
+            if isinstance(train_model, torch.nn.parallel.DistributedDataParallel):
+                if hasattr(train_model.module.head, "_training_targets"): # for RT-DETR
+                    train_model.module.head.set_training_targets(targets)
+            else:
+                if hasattr(train_model.head, "_training_targets"):
+                    train_model.head.set_training_targets(targets)
             out = train_model(images)
             loss_factory.calc(out, targets, phase='train')
 

--- a/src/netspresso_trainer/pipelines/task_processors/detection.py
+++ b/src/netspresso_trainer/pipelines/task_processors/detection.py
@@ -40,7 +40,7 @@ class DetectionProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
-            out = train_model(images, targets=targets)
+            out = train_model(images)
             loss_factory.calc(out, targets, phase='train')
 
         loss_factory.backward(self.grad_scaler)

--- a/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
@@ -35,7 +35,7 @@ class PoseEstimationProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
-            out = train_model(images, target=target)
+            out = train_model(images)
             loss_factory.calc(out, target, phase='train')
 
         loss_factory.backward(self.grad_scaler)

--- a/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
@@ -35,6 +35,12 @@ class PoseEstimationProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
+            if isinstance(train_model, torch.nn.parallel.DistributedDataParallel):
+                if hasattr(train_model.module.head, "_training_targets"): # for RT-DETR
+                    train_model.module.head.set_training_targets(target)
+            else:
+                if hasattr(train_model.head, "_training_targets"):
+                    train_model.head.set_training_targets(target)
             out = train_model(images)
             loss_factory.calc(out, target, phase='train')
 

--- a/src/netspresso_trainer/pipelines/task_processors/segmentation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/segmentation.py
@@ -41,7 +41,7 @@ class SegmentationProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
-            out = train_model(images, targets=target)
+            out = train_model(images)
             loss_factory.calc(out, target, phase='train')
 
         loss_factory.backward(self.grad_scaler)

--- a/src/netspresso_trainer/pipelines/task_processors/segmentation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/segmentation.py
@@ -41,6 +41,12 @@ class SegmentationProcessor(BaseTaskProcessor):
         optimizer.zero_grad()
 
         with torch.cuda.amp.autocast(enabled=self.mixed_precision):
+            if isinstance(train_model, torch.nn.parallel.DistributedDataParallel):
+                if hasattr(train_model.module.head, "_training_targets"): # for RT-DETR
+                    train_model.module.head.set_training_targets(target)
+            else:
+                if hasattr(train_model.head, "_training_targets"):
+                    train_model.head.set_training_targets(target)
             out = train_model(images)
             loss_factory.calc(out, target, phase='train')
 


### PR DESCRIPTION
## Description

This PR aims to refactor forward methods across models. Additionally, Modified the RT-DETR model architecture to move target parameters out of the forward method signature while maintaining denoising functionality during training.

Closes: #609 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Removed label_size, targets parameter from the forward() method
- Added internal state management with _training_targets field for RT-DETR head
- Implemented set_training_targets() and clear_training_targets() methods for RT-DETR head
- Updated training loop to call these methods before/after forward pass


## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.