### PR TITLE
[DF-237] Add feature to register ONNX model to mlflow registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## New Features:
 
-No changes to highlight.
+- Upload ONNX model to mlflow server if mlflow logging option is enabled by `hglee98` in [PR 621](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/621)
 
 ## Bug Fixes:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 torch==2.0.1
 torchvision==0.15.2
 onnx
+onnxruntime
 numpy
 pillow
 tqdm

--- a/src/netspresso_trainer/loggers/mlflow.py
+++ b/src/netspresso_trainer/loggers/mlflow.py
@@ -110,6 +110,17 @@ class MLFlowLogger:
             except Exception as e:
                 logger.error(f"Failed to log artifact {file}: {e}")
 
+    def log_onnx_model(self, model_path: Union[str, Path], input_example: torch.Tensor=None):
+        try:
+            import onnx
+            onnx_model = onnx.load_model(model_path)
+            # Convert torch tensor to numpy array if provided
+            if input_example is not None and isinstance(input_example, torch.Tensor):
+                input_example = input_example.cpu().numpy()
+            mlflow.onnx.log_model(onnx_model, "model", input_example=input_example)
+        except Exception as e:
+            logger.error(f"Failed to log ONNX model: {e}")
+
     def __call__(
         self,
         prefix: Literal["training", "validation", "evaluation", "inference"],

--- a/src/netspresso_trainer/loggers/mlflow.py
+++ b/src/netspresso_trainer/loggers/mlflow.py
@@ -112,19 +112,53 @@ class MLFlowLogger:
             except Exception as e:
                 logger.error(f"Failed to log artifact {file}: {e}")
 
-    def log_onnx_model(self, model_path: Union[str, Path], input_example: torch.Tensor=None):
+    def log_onnx_model(self, model_path: Union[str, Path], input_example: Optional[torch.Tensor] = None) -> bool:
+        """
+        Log an ONNX model to MLflow.
+
+        Args:
+            model_path: Path to the ONNX model file
+            input_example: Optional input tensor example for model signature
+
+        Returns:
+            bool: True if logging was successful, False otherwise
+        """
         try:
+            # Lazy import to avoid dependency issues
             import onnx
-            onnx_model = onnx.load_model(model_path)
-            # Convert torch tensor to numpy array if provided
-            if input_example is not None and isinstance(input_example, torch.Tensor):
-                input_example = input_example.cpu().numpy()
-                signature = mlflow.models.infer_signature(
-                    model_input=input_example,
-                )
+
+            # Load the ONNX model
+            onnx_model = onnx.load_model(str(model_path))
+
+            # Initialize signature as None
+            signature = None
+
+            # Process input example if provided
+            if input_example is not None:
+                if not isinstance(input_example, (torch.Tensor, np.ndarray)):
+                    logger.warning(f"Input example must be a torch.Tensor or np.ndarray, got {type(input_example)}")
+                else:
+                    # Convert torch tensor to numpy if needed
+                    if isinstance(input_example, torch.Tensor):
+                        input_example = input_example.detach().cpu().numpy()
+
+                    # Infer model signature from input example
+                    try:
+                        signature = mlflow.models.infer_signature(model_input=input_example)
+                    except Exception as sig_error:
+                        logger.warning(f"Failed to infer signature: {sig_error}")
+
+            # Log the model to MLflow
             mlflow.onnx.log_model(onnx_model, "model", signature=signature)
+            logger.info(f"Successfully logged ONNX model from {model_path}")
+            return True
+
+        except ImportError as ie:
+            logger.error(f"Failed to import required modules for ONNX logging: {ie}")
+            return False
         except Exception as e:
             logger.error(f"Failed to log ONNX model: {e}")
+            return False
 
     def __call__(
         self,

--- a/src/netspresso_trainer/loggers/mlflow.py
+++ b/src/netspresso_trainer/loggers/mlflow.py
@@ -149,7 +149,7 @@ class MLFlowLogger:
                         logger.warning(f"Failed to infer signature: {sig_error}")
 
             # Log the model to MLflow
-            mlflow.onnx.log_model(onnx_model, "model", signature=signature)
+            mlflow.onnx.log_model(onnx_model, "onnx_model", signature=signature)
             logger.info(f"Successfully logged ONNX model from {model_path}")
             return True
 

--- a/src/netspresso_trainer/loggers/mlflow.py
+++ b/src/netspresso_trainer/loggers/mlflow.py
@@ -147,8 +147,9 @@ class MLFlowLogger:
         }
 
         for section_name, flatten_func in config_sections.items():
-            section_conf = hp_omegaconf.get(section_name, None)
-            if section_conf is not None:
+            # Check if the section exists in the config and access it safely
+            if hasattr(hp_omegaconf, section_name):
+                section_conf = getattr(hp_omegaconf, section_name)
                 section_conf = OmegaConf.to_container(section_conf, resolve=True)
                 flattened_conf = flatten_func(section_conf)
                 mlflow.log_params(flattened_conf)

--- a/src/netspresso_trainer/loggers/mlflow.py
+++ b/src/netspresso_trainer/loggers/mlflow.py
@@ -15,6 +15,7 @@
 # ----------------------------------------------------------------------------
 import glob
 import os
+from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np

--- a/src/netspresso_trainer/loggers/mlflow.py
+++ b/src/netspresso_trainer/loggers/mlflow.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Literal, Optional, Union
 
 import numpy as np
 import torch
+import torch.nn as nn
 from loguru import logger
 from omegaconf import OmegaConf
 
@@ -118,7 +119,10 @@ class MLFlowLogger:
             # Convert torch tensor to numpy array if provided
             if input_example is not None and isinstance(input_example, torch.Tensor):
                 input_example = input_example.cpu().numpy()
-            mlflow.onnx.log_model(onnx_model, "model", input_example=input_example)
+                signature = mlflow.models.infer_signature(
+                    model_input=input_example,
+                )
+            mlflow.onnx.log_model(onnx_model, "model", signature=signature)
         except Exception as e:
             logger.error(f"Failed to log ONNX model: {e}")
 

--- a/src/netspresso_trainer/pipelines/train.py
+++ b/src/netspresso_trainer/pipelines/train.py
@@ -355,6 +355,9 @@ class TrainingPipeline(BasePipeline):
                     sample_input=self.sample_input.type(save_dtype),
                     opset_version=opset_version)
             logger.info(f"ONNX model converting and saved at {str(model_save_path.with_suffix('.onnx'))}")
+            if self.logger.use_mlflow:
+                self.logger.mlflow_logger.log_onnx_model(model_save_path.with_suffix('.onnx'),
+                input_example=self.sample_input.type(save_dtype))
 
             if not self.is_graphmodule_training:
                 save_graphmodule(best_model,


### PR DESCRIPTION
## Description
This PR introduces a new feature that automatically registers the exported ONNX model with the MLflow Model Registry as soon as training finishes. Previously, users had to manually upload or register their ONNX artifacts; with this change, registration becomes part of the training pipeline, ensuring the latest model is immediately registered and available for deployment.

Closes: #620 

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Add feature to register onnx model to mlflow model registry
- [misc] change linting error from OmegaConf
- Add `onnxruntime` to requirements.txt

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.