### PR TITLE
Refactoring sample saving

### DIFF
--- a/src/netspresso_trainer/dataloaders/base.py
+++ b/src/netspresso_trainer/dataloaders/base.py
@@ -35,6 +35,7 @@ class BaseCustomDataset(data.Dataset):
 
         self.transform = transform(conf_augmentation)
         self.samples = samples
+        self.sample_name_to_index = {sample['name']: i for i, sample in enumerate(samples)}
 
         self._root = conf_data.path.root
         self._idx_to_class = idx_to_class

--- a/src/netspresso_trainer/dataloaders/detection.py
+++ b/src/netspresso_trainer/dataloaders/detection.py
@@ -60,11 +60,11 @@ class DetectionSampleLoader(BaseSampleLoader):
 
             images = sorted(images, key=lambda k: natural_key(k))
             labels = sorted(labels, key=lambda k: natural_key(k))
-            images_and_targets.extend([{'image': str(image), 'label': str(label)} for image, label in zip(images, labels)])
+            images_and_targets.extend([{'image': str(image), 'label': str(label), 'name': Path(image).name} for image, label in zip(images, labels)])
 
         else:
             for ext in IMG_EXTENSIONS:
-                images_and_targets.extend([{'image': str(file), 'label': None}
+                images_and_targets.extend([{'image': str(file), 'label': None, 'name': Path(file).name}
                                         for file in chain(image_dir.glob(f'*{ext}'), image_dir.glob(f'*{ext.upper()}'))])
             images_and_targets = sorted(images_and_targets, key=lambda k: natural_key(k['image']))
 
@@ -157,7 +157,8 @@ class DetectionCustomDataset(BaseCustomDataset):
         w, h = img.size
 
         outputs = {}
-        outputs.update({'indices': index})
+        outputs['name'] = self.samples[index]['name']
+        outputs.update({'indices': torch.tensor(index, dtype=torch.int64)})
         if ann is None:
             out = self.transform(image=img)
             outputs.update({'pixel_values': out['image'], 'org_shape': (h, w)})

--- a/src/netspresso_trainer/dataloaders/utils/collate_fn.py
+++ b/src/netspresso_trainer/dataloaders/utils/collate_fn.py
@@ -14,6 +14,8 @@
 #
 # ----------------------------------------------------------------------------
 
+from typing import List
+
 import torch
 from torch.nn import functional as F
 
@@ -56,35 +58,8 @@ def classification_onehot_collate_fn(original_batch, num_classes):
     return outputs
 
 
-def detection_collate_fn(original_batch):
-    indices = []
-    pixel_values = []
-    bbox = []
-    label = []
-    org_shape = []
-    for data_sample in original_batch:
-        if 'indices' in data_sample:
-            indices.append(data_sample['indices'])
-        if 'pixel_values' in data_sample:
-            pixel_values.append(data_sample['pixel_values'])
-        if 'bbox' in data_sample:
-            bbox.append(data_sample['bbox'])
-        if 'label' in data_sample:
-            label.append(data_sample['label'])
-        if 'org_shape' in data_sample:
-            org_shape.append(data_sample['org_shape'])
-    outputs = {}
-    if len(indices) != 0:
-        indices = torch.tensor(indices, dtype=torch.long)
-        outputs.update({'indices': indices})
-    if len(pixel_values) != 0:
-        pixel_values = torch.stack(pixel_values, dim=0)
-        outputs.update({'pixel_values': pixel_values})
-    if len(bbox) != 0:
-        outputs.update({'bbox': bbox})
-    if len(label) != 0:
-        outputs.update({'label': label})
-    if len(org_shape) != 0:
-        outputs.update({'org_shape': org_shape})
-
+def default_collate_fn(original_batch):
+    # Assume all tensorizable data has already been converted to torch.Tensor
+    # And return a list of samples without any stacking
+    outputs = {key: [item[key] for item in original_batch] for key in original_batch[0]}
     return outputs

--- a/src/netspresso_trainer/loggers/builder.py
+++ b/src/netspresso_trainer/loggers/builder.py
@@ -20,12 +20,22 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 from .base import TrainingLogger
 
 
-def build_logger(conf, task: str, model_name: str, step_per_epoch: int, class_map: Dict[int, str], result_dir: Union[Path, str], epoch: Optional[int] = None):
+def build_logger(
+    conf,
+    task: str,
+    model_name: str,
+    step_per_epoch: int,
+    class_map: Dict[int, str],
+    result_dir: Union[Path, str],
+    dataloader,
+    epoch: Optional[int] = None,
+):
     training_logger = TrainingLogger(conf,
                                      task=task, model=model_name,
                                      step_per_epoch=step_per_epoch,
                                      class_map=class_map,
                                      result_dir=result_dir,
-                                     epoch=epoch)
+                                     epoch=epoch,
+                                     dataloader=dataloader)
 
     return training_logger

--- a/src/netspresso_trainer/pipelines/builder.py
+++ b/src/netspresso_trainer/pipelines/builder.py
@@ -116,7 +116,8 @@ def build_pipeline(
             train_logger = build_logger(conf, task, model_name,
                                         step_per_epoch=train_step_per_epoch,
                                         class_map=class_map,
-                                        result_dir=logging_dir,)
+                                        result_dir=logging_dir,
+                                        dataloader=eval_dataloader,)
 
         # Build pipeline
         pipeline = PIPELINES[pipeline_type](conf=conf,
@@ -156,7 +157,8 @@ def build_pipeline(
             eval_logger = build_logger(conf, task, model_name,
                                        step_per_epoch=0,
                                        class_map=class_map,
-                                       result_dir=logging_dir,)
+                                       result_dir=logging_dir,
+                                       dataloader=eval_dataloader,)
         # Build pipeline
         pipeline = PIPELINES[pipeline_type](conf=conf,
                                             task=task,
@@ -181,7 +183,8 @@ def build_pipeline(
             eval_logger = build_logger(conf, task, model_name,
                                        step_per_epoch=0,
                                        class_map=class_map,
-                                       result_dir=logging_dir,)
+                                       result_dir=logging_dir,
+                                       dataloader=test_dataloader,)
         # Build pipeline
         pipeline = PIPELINES[pipeline_type](conf=conf,
                                             task=task,

--- a/src/netspresso_trainer/pipelines/evaluation.py
+++ b/src/netspresso_trainer/pipelines/evaluation.py
@@ -74,25 +74,20 @@ class EvaluationPipeline(BasePipeline):
         self._is_ready()
         self.timer.start_record(name='evaluation')
 
-        returning_samples = ProcessorStepOut.empty()
         outputs = ProcessorStepOut.empty()
         for _idx, batch in enumerate(tqdm(self.eval_dataloader, leave=False)):
             out = self.task_processor.valid_step(self.model, batch, self.loss_factory, self.metric_factory)
-            outputs['images'].extend(out['images'])
-            outputs['pred'].extend(out['pred'])
-            outputs['target'].extend(out['target'])
+            if self.single_gpu_or_rank_zero:
+                outputs['name'].extend(out['name'])
+                outputs['pred'].extend(out['pred'])
+                outputs['target'].extend(out['target'])
 
-            if self.single_gpu_or_rank_zero and (len(returning_samples['images']) < self.logger.num_sample_images):
-                add_sample_num = self.logger.num_sample_images - len(returning_samples['images'])
-                returning_samples['images'].extend(out['images'][:add_sample_num])
-                returning_samples['pred'].extend(out['pred'][:add_sample_num])
-                returning_samples['target'].extend(out['target'][:add_sample_num])
         self.task_processor.get_metric_with_all_outputs(outputs, phase='valid', metric_factory=self.metric_factory)
 
         self.timer.end_record(name='evaluation')
         if self.single_gpu_or_rank_zero:
             time_for_evaluation = self.timer.get(name='evaluation', as_pop=False)
-            self.log_end_evaluation(time_for_evaluation=time_for_evaluation, valid_samples=returning_samples)
+            self.log_end_evaluation(time_for_evaluation=time_for_evaluation, valid_samples=outputs)
 
     def log_end_evaluation(
         self,

--- a/src/netspresso_trainer/pipelines/task_processors/classification.py
+++ b/src/netspresso_trainer/pipelines/task_processors/classification.py
@@ -167,23 +167,19 @@ class ClassificationProcessor(BaseTaskProcessor):
         pass
 
     def get_predictions(self, results, class_map):
-        assert "pred" in results and "images" in results
+        assert "pred" in results and "name" in results
 
         predictions = []
-        for idx in range(len(results['images'])):
-            image = results['images'][idx]
-            height, width = image.shape[-2:]
+        for idx in range(len(results['name'])):
+            sample = results['name'][idx]
             label = results['pred'][idx]['label']
             conf_score = results['pred'][idx]['conf_score']
             predictions.append(
                 {
+                    "sample": sample,
                     "class": int(label[0]),
-                    "name": class_map[int(label[0])],
+                    "class_name": class_map[int(label[0])],
                     "conf_score": float(conf_score[0]),
-                    "shape": {
-                        "width": width,
-                        "height": height
-                    }
                 }
             )
 

--- a/src/netspresso_trainer/pipelines/task_processors/detection.py
+++ b/src/netspresso_trainer/pipelines/task_processors/detection.py
@@ -16,6 +16,7 @@
 
 from typing import Literal, Optional
 
+import numpy as np
 import torch
 
 from netspresso_trainer.models.utils import set_training_targets
@@ -32,6 +33,8 @@ class DetectionProcessor(BaseTaskProcessor):
     def train_step(self, train_model, batch, optimizer, loss_factory, metric_factory):
         train_model.train()
         images, labels, bboxes = batch['pixel_values'], batch['label'], batch['bbox']
+        images = torch.stack(images, dim=0)
+
         images = images.to(self.devices)
         targets = [{"boxes": box.to(self.devices), "labels": label.to(self.devices),}
                    for box, label in zip(bboxes, labels)]
@@ -86,7 +89,11 @@ class DetectionProcessor(BaseTaskProcessor):
 
     def valid_step(self, eval_model, batch, loss_factory, metric_factory):
         eval_model.eval()
+        name = batch['name']
         indices, images, labels, bboxes = batch['indices'], batch['pixel_values'], batch['label'], batch['bbox']
+        indices = torch.stack(indices, dim=0)
+        images = torch.stack(images, dim=0)
+
         images = images.to(self.devices)
         targets = [{"boxes": box.to(self.devices), "labels": label.to(self.devices)}
                    for box, label in zip(bboxes, labels)]
@@ -104,6 +111,7 @@ class DetectionProcessor(BaseTaskProcessor):
         if self.conf.distributed:
             # Remove dummy samples, they only come in distributed environment
             images = images[indices != -1]
+            name = np.array(name)[indices != -1].tolist()
             filtered_bboxes = []
             filtered_labels = []
             filtered_pred = []
@@ -117,24 +125,24 @@ class DetectionProcessor(BaseTaskProcessor):
             pred = filtered_pred
 
             # Gather phase
+            gathered_name = [None for _ in range(torch.distributed.get_world_size())]
             gathered_bboxes = [None for _ in range(torch.distributed.get_world_size())]
             gathered_labels = [None for _ in range(torch.distributed.get_world_size())]
             gathered_pred = [None for _ in range(torch.distributed.get_world_size())]
+            torch.distributed.gather_object(name, gathered_name if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.gather_object(bboxes, gathered_bboxes if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.gather_object(labels, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.gather_object(pred, gathered_pred if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                gathered_bboxes = sum(gathered_bboxes, [])
-                gathered_labels = sum(gathered_labels, [])
-                gathered_pred = sum(gathered_pred, [])
-                bboxes = gathered_bboxes
-                labels = gathered_labels
-                pred = gathered_pred
+                name = sum(gathered_name, [])
+                bboxes = sum(gathered_bboxes, [])
+                labels = sum(gathered_labels, [])
+                pred = sum(gathered_pred, [])
 
         step_out = ProcessorStepOut.empty()
         if self.single_gpu_or_rank_zero:
-            step_out['images'] = list(images.detach().cpu().numpy())
+            step_out['name'] = name
             step_out['target'] = [{'boxes': bbox.detach().cpu().numpy(), 'labels': label.detach().cpu().numpy()}
                                   for bbox, label in zip(bboxes, labels)]
             step_out['pred'] = [{'boxes': bboxes,
@@ -145,7 +153,11 @@ class DetectionProcessor(BaseTaskProcessor):
 
     def test_step(self, test_model, batch):
         test_model.eval()
+        name = batch['name']
         indices, images = batch['indices'], batch['pixel_values']
+        indices = torch.stack(indices, dim=0)
+        images = torch.stack(images, dim=0)
+
         images = images.to(self.devices)
 
         out = test_model(images)
@@ -160,21 +172,23 @@ class DetectionProcessor(BaseTaskProcessor):
                 if bool_idx:
                     filtered_pred.append(pred[idx])
             pred = filtered_pred
+            name = np.array(name)[indices != -1].tolist()
 
             # Gather phase
+            gathered_name = [None for _ in range(torch.distributed.get_world_size())]
             gathered_pred = [None for _ in range(torch.distributed.get_world_size())]
             torch.distributed.gather_object(pred, gathered_pred if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
-                gathered_pred = sum(gathered_pred, [])
-                pred = gathered_pred
+                name = sum(gathered_name, [])
+                pred = sum(gathered_pred, [])
 
         step_out = ProcessorStepOut.empty()
         if self.single_gpu_or_rank_zero:
-            step_out['images'] = list(images.detach().cpu().numpy())
-            step_out['pred'] = [{'post_boxes': bboxes,
-                                 'post_scores': scores,
-                                 'post_labels': labels}
+            step_out['name'] = name
+            step_out['pred'] = [{'boxes': bboxes,
+                                 'scores': scores,
+                                 'labels': labels}
                                 for bboxes, scores, labels in pred]
         return step_out
 
@@ -185,14 +199,12 @@ class DetectionProcessor(BaseTaskProcessor):
             metric_factory.update(pred, target=targets, phase=phase)
 
     def get_predictions(self, results, class_map):
-        assert "pred" in results and "images" in results
+        assert "pred" in results and "name" in results
 
         predictions = []
         for idx in range(len(results['pred'])):
-            image = results['images'][idx]
-            height, width = image.shape[-2:]
             preds = []
-            for bbox, label, score in zip(results['pred'][idx]['post_boxes'], results['pred'][idx]['post_labels'], results['pred'][idx]['post_scores']):
+            for bbox, label, score in zip(results['pred'][idx]['boxes'], results['pred'][idx]['labels'], results['pred'][idx]['scores']):
                 x1 = int(bbox[0])
                 y1 = int(bbox[1])
                 x2 = int(bbox[2])
@@ -215,11 +227,8 @@ class DetectionProcessor(BaseTaskProcessor):
                 )
             predictions.append(
                 {
+                    "sample": results['name'][idx],
                     "bboxes": preds,
-                    "shape": {
-                        "width": width,
-                        "height": height
-                    }
                 }
             )
 

--- a/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
+++ b/src/netspresso_trainer/pipelines/task_processors/pose_estimation.py
@@ -22,6 +22,7 @@ import torch
 from netspresso_trainer.models.utils import set_training_targets
 
 from .base import BaseTaskProcessor
+from ...utils.protocols import ProcessorStepOut
 
 
 class PoseEstimationProcessor(BaseTaskProcessor):
@@ -31,6 +32,8 @@ class PoseEstimationProcessor(BaseTaskProcessor):
     def train_step(self, train_model, batch, optimizer, loss_factory, metric_factory):
         train_model.train()
         images, keypoints = batch['pixel_values'], batch['keypoints']
+        images = torch.stack(images, dim=0)
+        keypoints = torch.stack(keypoints, dim=0)
         images = images.to(self.devices)
         target = {'keypoints': keypoints.to(self.devices)}
 
@@ -64,16 +67,20 @@ class PoseEstimationProcessor(BaseTaskProcessor):
                 pred = np.concatenate(gathered_pred, axis=0)
                 keypoints = np.concatenate(gathered_labels, axis=0)
 
+        step_out = ProcessorStepOut.empty()
         if self.single_gpu_or_rank_zero:
-            logs = {
-                'target': keypoints,
-                'pred': pred
-            }
-            return dict(logs.items())
+            step_out['pred'] = list(pred)
+            step_out['target'] = list(keypoints)
+
+        return step_out
 
     def valid_step(self, eval_model, batch, loss_factory, metric_factory):
         eval_model.eval()
+        name = batch['name']
         indices, images, keypoints = batch['indices'], batch['pixel_values'], batch['keypoints']
+        indices = torch.stack(indices, dim=0)
+        images = torch.stack(images, dim=0)
+        keypoints = torch.stack(keypoints, dim=0)
         images = images.to(self.devices)
         target = {'keypoints': keypoints.to(self.devices)}
 
@@ -85,30 +92,37 @@ class PoseEstimationProcessor(BaseTaskProcessor):
         indices = indices.numpy()
         keypoints = keypoints.detach().cpu().numpy()
         if self.conf.distributed:
+            name = np.array(name)[indices != -1].tolist()
             pred = pred[indices != -1]
             keypoints = keypoints[indices != -1]
 
+            gathered_name = [None for _ in range(torch.distributed.get_world_size())]
             gathered_pred = [None for _ in range(torch.distributed.get_world_size())]
             gathered_labels = [None for _ in range(torch.distributed.get_world_size())]
 
+            torch.distributed.gather_object(name, gathered_name if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.gather_object(pred, gathered_pred if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.gather_object(keypoints, gathered_labels if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
+                name = sum(gathered_name, [])
                 pred = np.concatenate(gathered_pred, axis=0)
                 keypoints = np.concatenate(gathered_labels, axis=0)
 
+        step_out = ProcessorStepOut.empty()
         if self.single_gpu_or_rank_zero:
-            logs = {
-                'images': images.detach().cpu().numpy(),
-                'target': keypoints,
-                'pred': pred
-            }
-            return dict(logs.items())
+            step_out['name'] = name
+            step_out['pred'] = list(pred)
+            step_out['target'] = list(keypoints)
+
+        return step_out
 
     def test_step(self, test_model, batch):
         test_model.eval()
+        name = batch['name']
         indices, images = batch['indices'], batch['pixel_values']
+        indices = torch.stack(indices, dim=0)
+        images = torch.stack(images, dim=0)
         images = images.to(self.devices)
 
         out = test_model(images)
@@ -117,19 +131,26 @@ class PoseEstimationProcessor(BaseTaskProcessor):
 
         indices = indices.numpy()
         if self.conf.distributed:
+            name = np.array(name)[indices != -1].tolist()
             pred = pred[indices != -1]
 
+            gathered_name = [None for _ in range(torch.distributed.get_world_size())]
             gathered_pred = [None for _ in range(torch.distributed.get_world_size())]
 
+            torch.distributed.gather_object(name, gathered_name if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.gather_object(pred, gathered_pred if torch.distributed.get_rank() == 0 else None, dst=0)
             torch.distributed.barrier()
             if torch.distributed.get_rank() == 0:
                 gathered_pred = sum(gathered_pred, [])
+                name = sum(gathered_name, [])
                 pred = gathered_pred
 
+        step_out = ProcessorStepOut.empty()
         if self.single_gpu_or_rank_zero:
-            results = {'images': images.detach().cpu().numpy(), 'pred': pred}
-            return results
+            step_out['name'] = name
+            step_out['pred'] = list(pred)
+
+        return step_out
 
     def get_metric_with_all_outputs(self, outputs, phase: Literal['train', 'valid'], metric_factory):
         if self.single_gpu_or_rank_zero:

--- a/src/netspresso_trainer/utils/protocols.py
+++ b/src/netspresso_trainer/utils/protocols.py
@@ -2,10 +2,10 @@ from typing import List, TypedDict
 
 
 class ProcessorStepOut(TypedDict):
-    images: List
+    name: List
     pred: List
     target: List
 
     @classmethod
     def empty(cls):
-        return cls(images=[], pred=[], target=[])
+        return cls(name=[], pred=[], target=[])


### PR DESCRIPTION
## Description

Please include a summary of this pull request in English. If it closes an issue, please mention it here.

Closes: #(issue number)

We recommend to link at least one existing issue for PR. Before your create a PR, please check if there is an issue for this change.  

## Change(s)

- Return sample name instead of image tensor at each train/val/infer step
  - ImageSaver logger use that sample name to save visualized results
- All Dataset class return dict type object at getitem
- collate_fn has simplified

## Code Formatting

If you PR to either `master` or `dev` branch, you should follow the code linting process. Please check your code with `lint_check.sh` in `./scripts` directory.
For more information, please read the contribution guide in `CONTRIBUTING.md`. 

## Changelog

If your PR is granted to `dev` branch, codeowner will add a brief summary of the change to the **Upcoming Release** section of the [`CHANGELOG.md`](https://github.com/Nota-NetsPresso/netspresso-trainer/blob/master/CHANGELOG.md) file including a link to the PR (formatted in markdown) and a link to your github profile.

For example,

```
- Added a new feature by `@myusername` in [PR 2023](https://github.com/Nota-NetsPresso/netspresso-trainer/pull/2023)
```

Please enable **Allow edits and access to secrets by maintainers** so that our maintainers can update the `CHANGELOG.md`.